### PR TITLE
Add JSONBin chunk uploader

### DIFF
--- a/JSONBin.com/jsonbin_uploader.py
+++ b/JSONBin.com/jsonbin_uploader.py
@@ -1,0 +1,268 @@
+import argparse
+import base64
+import hashlib
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+
+import requests
+
+
+JSONBIN_CREATE_URL = "https://api.jsonbin.io/v3/b"
+DEFAULT_CHUNK_SIZE = 500 * 1024
+API_KEYS_ENV = "JSONBIN_API_KEYS"
+
+
+def parse_size(value):
+    text = value.strip().lower()
+    units = {
+        "b": 1,
+        "kb": 1024,
+        "mb": 1024 * 1024,
+    }
+    for suffix, multiplier in sorted(units.items(), key=lambda item: len(item[0]), reverse=True):
+        if text.endswith(suffix):
+            return int(float(text[: -len(suffix)]) * multiplier)
+    return int(text)
+
+
+def parse_api_keys(values):
+    keys = []
+    for value in values:
+        keys.extend(part.strip() for part in value.split(",") if part.strip())
+
+    env_value = os.environ.get(API_KEYS_ENV, "")
+    keys.extend(part.strip() for part in env_value.split(",") if part.strip())
+    return keys
+
+
+def sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(filepath):
+    digest = hashlib.sha256()
+    with Path(filepath).open("rb") as file_handle:
+        for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def iter_file_chunks(filepath, chunk_size):
+    with Path(filepath).open("rb") as file_handle:
+        index = 0
+        while True:
+            chunk = file_handle.read(chunk_size)
+            if not chunk:
+                break
+            yield index, chunk
+            index += 1
+
+
+def build_chunk_record(file_id, file_path, file_hash, total_parts, chunk_index, chunk_data):
+    return {
+        "upload_id": file_id,
+        "file_id": file_id,
+        "original_filename": file_path.name,
+        "total_parts": total_parts,
+        "part_index": chunk_index,
+        "chunk_size": len(chunk_data),
+        "chunk_sha256": sha256_bytes(chunk_data),
+        "file_sha256": file_hash,
+        "uploaded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "content_encoding": "base64",
+        "content": base64.b64encode(chunk_data).decode("ascii"),
+    }
+
+
+def create_jsonbin_record(record, api_key, bin_name=None, private=True, collection_id=None):
+    headers = {
+        "Content-Type": "application/json",
+        "X-Master-Key": api_key,
+        "X-Bin-Private": "true" if private else "false",
+    }
+    if bin_name:
+        headers["X-Bin-Name"] = bin_name[:128]
+    if collection_id:
+        headers["X-Collection-Id"] = collection_id
+
+    response = requests.post(JSONBIN_CREATE_URL, headers=headers, json=record, timeout=60)
+    try:
+        payload = response.json()
+    except ValueError:
+        response.raise_for_status()
+        raise
+
+    if response.status_code >= 400:
+        message = payload.get("message", response.text)
+        raise RuntimeError(message)
+    return payload
+
+
+def create_jsonbin_record_with_retries(record, api_keys, key_start_index, args, bin_name):
+    errors = []
+    attempts = max(1, args.retry_attempts + 1)
+
+    for attempt in range(attempts):
+        api_key_index = (key_start_index + attempt) % len(api_keys)
+        api_key = api_keys[api_key_index]
+        try:
+            response = create_jsonbin_record(
+                record,
+                api_key,
+                bin_name=bin_name,
+                private=not args.public,
+                collection_id=args.collection_id,
+            )
+            return response, api_key_index, attempt
+        except (requests.RequestException, RuntimeError) as exc:
+            errors.append(str(exc))
+            if attempt < attempts - 1 and args.retry_delay > 0:
+                time.sleep(args.retry_delay)
+
+    raise RuntimeError("; ".join(errors))
+
+
+def upload_file(args):
+    file_path = Path(args.file)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"File not found: {args.file}")
+
+    api_keys = parse_api_keys(args.api_key)
+    if not api_keys:
+        raise ValueError(f"Provide at least one API key with --api-key or {API_KEYS_ENV}")
+
+    chunk_size = parse_size(args.chunk_size)
+    if chunk_size <= 0:
+        raise ValueError("Chunk size must be greater than zero")
+
+    file_size = file_path.stat().st_size
+    total_parts = (file_size + chunk_size - 1) // chunk_size
+    file_id = args.upload_id or str(uuid.uuid4())
+    file_hash = sha256_file(file_path)
+    uploaded_parts = []
+    failed_parts = []
+
+    for chunk_index, chunk_data in iter_file_chunks(file_path, chunk_size):
+        record = build_chunk_record(file_id, file_path, file_hash, total_parts, chunk_index, chunk_data)
+        key_start_index = chunk_index % len(api_keys)
+        bin_name = f"{file_path.name}-{file_id}-part-{chunk_index + 1}-of-{total_parts}"
+
+        try:
+            response, api_key_index, retry_count = create_jsonbin_record_with_retries(
+                record,
+                api_keys,
+                key_start_index,
+                args,
+                bin_name,
+            )
+            metadata = response.get("metadata", {})
+            uploaded_parts.append(
+                {
+                    "part_index": chunk_index,
+                    "bin_id": metadata.get("id"),
+                    "chunk_sha256": record["chunk_sha256"],
+                    "chunk_size": record["chunk_size"],
+                    "api_key_index": api_key_index,
+                    "retry_count": retry_count,
+                }
+            )
+            if args.verbose:
+                print(f"Uploaded part {chunk_index + 1}/{total_parts}: {metadata.get('id')}")
+        except (requests.RequestException, RuntimeError) as exc:
+            failed_parts.append({"part_index": chunk_index, "error": str(exc)})
+            if args.verbose:
+                print(f"Failed part {chunk_index + 1}/{total_parts}: {exc}")
+            if len(failed_parts) > args.max_failures:
+                break
+
+    manifest = {
+        "upload_id": file_id,
+        "file_id": file_id,
+        "original_filename": file_path.name,
+        "file_size": file_size,
+        "file_sha256": file_hash,
+        "chunk_size": chunk_size,
+        "total_parts": total_parts,
+        "uploaded_parts": uploaded_parts,
+        "failed_parts": failed_parts,
+        "complete": len(uploaded_parts) == total_parts and not failed_parts,
+    }
+
+    if args.manifest:
+        Path(args.manifest).write_text(json.dumps(manifest, indent=4), encoding="utf-8")
+
+    return manifest
+
+
+def reconstruct_from_manifest(args):
+    manifest = json.loads(Path(args.manifest_file).read_text(encoding="utf-8"))
+    parts_dir = Path(args.parts_dir)
+    output_path = Path(args.output or manifest["original_filename"])
+    expected_parts = manifest["total_parts"]
+
+    with output_path.open("wb") as output:
+        for index in range(expected_parts):
+            part_path = parts_dir / f"{index}.part"
+            if not part_path.is_file():
+                raise FileNotFoundError(f"Missing chunk file: {part_path}")
+            data = part_path.read_bytes()
+            output.write(data)
+
+    actual_hash = sha256_file(output_path)
+    if actual_hash != manifest["file_sha256"]:
+        raise ValueError("Reconstructed file hash does not match manifest")
+
+    return {
+        "output": str(output_path),
+        "file_sha256": actual_hash,
+        "verified": True,
+    }
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Upload file chunks to JSONBin.io")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    upload = subparsers.add_parser("upload", help="Split a file and upload chunks to JSONBin")
+    upload.add_argument("file", help="File to upload")
+    upload.add_argument("--api-key", action="append", default=[], help="JSONBin API key. Can be repeated or comma-separated")
+    upload.add_argument("--chunk-size", default=str(DEFAULT_CHUNK_SIZE), help="Chunk size in bytes, KB, or MB")
+    upload.add_argument("--upload-id", help="Logical upload/file id. Defaults to a UUID")
+    upload.add_argument("--manifest", help="Write upload manifest to this JSON file")
+    upload.add_argument("--collection-id", help="Optional JSONBin collection id")
+    upload.add_argument("--public", action="store_true", help="Create public bins instead of private bins")
+    upload.add_argument("--max-failures", type=int, default=0, help="Abort after more than this many failed chunks")
+    upload.add_argument("--retry-attempts", type=int, default=3, help="Retry attempts per chunk")
+    upload.add_argument("--retry-delay", type=float, default=1.0, help="Seconds to wait between retries")
+    upload.add_argument("--verbose", action="store_true", help="Print upload progress")
+
+    reconstruct = subparsers.add_parser("reconstruct-manifest", help="Reconstruct local chunk files using a manifest")
+    reconstruct.add_argument("manifest_file", help="Manifest JSON file")
+    reconstruct.add_argument("--parts-dir", required=True, help="Directory containing chunk files named 0.part, 1.part, ...")
+    reconstruct.add_argument("--output", help="Output file path")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.command == "upload":
+            result = upload_file(args)
+        elif args.command == "reconstruct-manifest":
+            result = reconstruct_from_manifest(args)
+        else:
+            raise ValueError(f"Unknown command: {args.command}")
+    except (OSError, ValueError, RuntimeError, requests.RequestException) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=4))
+        return 1
+
+    print(json.dumps({"ok": True, "result": result}, indent=4))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ python3 bayfiles.py
 
 **Binary File**
 
+```shell
 ./bayfiles
 ```
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,46 @@ data :
 </details>
 
 <details>
+  <summary><h4>JSONBin</h4></summary>
+
+JSONBin.io chunk uploader for splitting files into JSON records.
+
+The JSONBin API requires an API key. Pass one or more keys with `--api-key`, or set the `JSONBIN_API_KEYS` environment variable with comma-separated keys.
+
+<details>
+<summary>Usage</summary>
+
+**Upload a file in chunks**
+
+```shell
+python JSONBin.com/jsonbin_uploader.py upload path/to/file.txt --api-key YOUR_API_KEY --manifest upload-manifest.json
+```
+
+**Use multiple API keys**
+
+```shell
+python JSONBin.com/jsonbin_uploader.py upload path/to/file.txt --api-key KEY_1 --api-key KEY_2 --chunk-size 500KB
+```
+
+**Configure retries**
+
+```shell
+python JSONBin.com/jsonbin_uploader.py upload path/to/file.txt --api-key KEY_1 --retry-attempts 3 --retry-delay 1
+```
+
+**Use an environment variable**
+
+```shell
+set JSONBIN_API_KEYS=KEY_1,KEY_2
+python JSONBin.com/jsonbin_uploader.py upload path/to/file.txt --manifest upload-manifest.json
+```
+
+Each uploaded chunk includes metadata such as the original filename, logical upload id, part index, total part count, chunk hash, full file hash, upload timestamp, and base64-encoded content.
+
+</details>
+</details>
+
+<details>
   <summary><h4>AnonFiles (**DEPRECATED**)</h4></summary>
 
 Description of AnonFiles
@@ -440,7 +480,6 @@ python3 bayfiles.py
 
 **Binary File**
 
-```shell
 ./bayfiles
 ```
 

--- a/tests/test_jsonbin_uploader.py
+++ b/tests/test_jsonbin_uploader.py
@@ -1,0 +1,99 @@
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "JSONBin.com" / "jsonbin_uploader.py"
+SPEC = importlib.util.spec_from_file_location("jsonbin_uploader", MODULE_PATH)
+jsonbin_uploader = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(jsonbin_uploader)
+
+
+class JsonBinUploaderTests(unittest.TestCase):
+    def test_parse_size_accepts_bytes_and_binary_units(self):
+        cases = {
+            "42": 42,
+            "42b": 42,
+            "1KB": 1024,
+            "1.5mb": 1572864,
+        }
+
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(jsonbin_uploader.parse_size(value), expected)
+
+    def test_parse_api_keys_combines_arguments_and_environment(self):
+        original_value = os.environ.get(jsonbin_uploader.API_KEYS_ENV)
+        os.environ[jsonbin_uploader.API_KEYS_ENV] = "env-key-1, env-key-2"
+        try:
+            self.assertEqual(
+                jsonbin_uploader.parse_api_keys(["arg-key-1,arg-key-2", "arg-key-3"]),
+                ["arg-key-1", "arg-key-2", "arg-key-3", "env-key-1", "env-key-2"],
+            )
+        finally:
+            if original_value is None:
+                os.environ.pop(jsonbin_uploader.API_KEYS_ENV, None)
+            else:
+                os.environ[jsonbin_uploader.API_KEYS_ENV] = original_value
+
+    def test_build_chunk_record_contains_verifiable_metadata(self):
+        file_path = Path("sample.txt")
+        chunk_data = b"hello"
+        file_hash = jsonbin_uploader.sha256_bytes(chunk_data)
+
+        record = jsonbin_uploader.build_chunk_record(
+            "upload-1",
+            file_path,
+            file_hash,
+            total_parts=1,
+            chunk_index=0,
+            chunk_data=chunk_data,
+        )
+
+        self.assertEqual(record["upload_id"], "upload-1")
+        self.assertEqual(record["original_filename"], "sample.txt")
+        self.assertEqual(record["chunk_size"], 5)
+        self.assertEqual(record["chunk_sha256"], file_hash)
+        self.assertEqual(record["file_sha256"], file_hash)
+        self.assertEqual(record["content_encoding"], "base64")
+        self.assertEqual(record["content"], "aGVsbG8=")
+
+    def test_reconstruct_manifest_writes_and_verifies_output(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            parts_dir = workspace / "parts"
+            parts_dir.mkdir()
+            expected_content = b"hello world"
+            (parts_dir / "0.part").write_bytes(expected_content[:6])
+            (parts_dir / "1.part").write_bytes(expected_content[6:])
+
+            manifest = {
+                "original_filename": "sample.txt",
+                "total_parts": 2,
+                "file_sha256": jsonbin_uploader.sha256_bytes(expected_content),
+            }
+            manifest_file = workspace / "manifest.json"
+            manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+            output_file = workspace / "output.txt"
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "manifest_file": str(manifest_file),
+                    "parts_dir": str(parts_dir),
+                    "output": str(output_file),
+                },
+            )
+
+            result = jsonbin_uploader.reconstruct_from_manifest(args)
+
+            self.assertEqual(output_file.read_bytes(), expected_content)
+            self.assertTrue(result["verified"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a JSONBin.io chunk uploader that splits files into configurable parts and stores each chunk as a JSONBin record.
- Supports one or more API keys through repeated/comma-separated `--api-key` values or `JSONBIN_API_KEYS`.
- Rotates API keys by chunk and retries failed uploads with configurable retry count and delay.
- Adds per-chunk metadata: original filename, logical upload id, total parts, part index, chunk size, chunk hash, full file hash, upload timestamp, and base64 content.
- Produces an upload manifest with uploaded and failed parts.
- Includes a local `reconstruct-manifest` command to verify/rebuild chunk files from a manifest and local part files.
- Adds unit coverage for size parsing, API key loading, chunk record metadata, and manifest reconstruction.

## Validation

- `python -m py_compile JSONBin.com\jsonbin_uploader.py tests\test_jsonbin_uploader.py`
- `python -m unittest tests.test_jsonbin_uploader`
- `python JSONBin.com\jsonbin_uploader.py --help`
- `python JSONBin.com\jsonbin_uploader.py upload README.md --chunk-size 1KB` returns a clear missing-key error.
- Local chunk/reconstruct test produced 3 chunks and verified the reconstructed file hash.

Closes #5.