### PR TITLE
Add shared provider core

### DIFF
--- a/fileuploader/__init__.py
+++ b/fileuploader/__init__.py
@@ -1,0 +1,11 @@
+from .core import FileUploaderCore
+from .models import ProviderError, ProviderInfo, UploadResult
+from .registry import create_default_registry
+
+__all__ = [
+    "FileUploaderCore",
+    "ProviderError",
+    "ProviderInfo",
+    "UploadResult",
+    "create_default_registry",
+]

--- a/fileuploader/core.py
+++ b/fileuploader/core.py
@@ -1,0 +1,24 @@
+from collections.abc import Iterable
+
+from .models import ProviderInfo
+from .registry import ProviderRegistry, create_default_registry
+
+
+class FileUploaderCore:
+    def __init__(self, registry: ProviderRegistry | None = None):
+        self.registry = registry or create_default_registry()
+
+    def services(self, include_deprecated: bool = True) -> list[ProviderInfo]:
+        providers: Iterable = self.registry.providers()
+        if not include_deprecated:
+            providers = [provider for provider in providers if not provider.info.deprecated]
+        return [provider.info for provider in providers]
+
+    def upload(self, service: str, filepath: str, **options):
+        return self.registry.get(service).upload(filepath, **options)
+
+    def download(self, service: str, **options):
+        return self.registry.get(service).download(**options)
+
+    def info(self, service: str, file_id: str, **options):
+        return self.registry.get(service).info_file(file_id, **options)

--- a/fileuploader/models.py
+++ b/fileuploader/models.py
@@ -1,0 +1,46 @@
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+class ProviderError(RuntimeError):
+    def __init__(self, provider: str, message: str, code: str | None = None):
+        super().__init__(message)
+        self.provider = provider
+        self.message = message
+        self.code = code
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "message": self.message,
+            "code": self.code,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderInfo:
+    name: str
+    display_name: str
+    active: bool = True
+    supports_upload: bool = True
+    supports_download: bool = False
+    supports_info: bool = False
+    requires_api_key: bool = False
+    deprecated: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class UploadResult:
+    provider: str
+    status: bool
+    url: str | None = None
+    short_url: str | None = None
+    file_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/fileuploader/providers.py
+++ b/fileuploader/providers.py
@@ -1,0 +1,230 @@
+import base64
+import hashlib
+import os
+import time
+import uuid
+from pathlib import Path
+
+import requests
+
+from .models import ProviderError, ProviderInfo, UploadResult
+
+
+class BaseProvider:
+    info = ProviderInfo(name="base", display_name="Base")
+
+    def __init__(self, http_client=None):
+        self.http = http_client or requests
+
+    def upload(self, filepath, **options):
+        raise ProviderError(self.info.name, "Upload is not supported by this provider")
+
+    def download(self, **options):
+        raise ProviderError(self.info.name, "Download is not supported by this provider")
+
+    def info_file(self, file_id, **options):
+        raise ProviderError(self.info.name, "File info is not supported by this provider")
+
+    def _ensure_file(self, filepath):
+        path = Path(filepath)
+        if not path.is_file():
+            raise ProviderError(self.info.name, f"File not found: {filepath}", code="file_not_found")
+        return path
+
+    def _post_file(self, url, filepath, **kwargs):
+        path = self._ensure_file(filepath)
+        try:
+            with path.open("rb") as file_handle:
+                response = self.http.post(url, files={"file": (path.name, file_handle)}, **kwargs)
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._json_response(response)
+
+    def _json_response(self, response):
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ProviderError(self.info.name, "Provider returned invalid JSON", code="invalid_json") from exc
+        if getattr(response, "status_code", 200) >= 400:
+            message = payload.get("message") or payload.get("error", {}).get("message") or response.text
+            raise ProviderError(self.info.name, message, code="http_error")
+        return payload
+
+
+class GoFileProvider(BaseProvider):
+    info = ProviderInfo(
+        name="gofile",
+        display_name="GoFile",
+        supports_download=True,
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        payload = self._post_file("https://upload.gofile.io/uploadfile", filepath)
+        if payload.get("status") not in ("ok", True):
+            raise ProviderError(self.info.name, str(payload), code="upload_failed")
+        data = payload.get("data", {})
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=data.get("downloadPage"),
+            file_id=data.get("fileId") or data.get("code"),
+            metadata=data,
+            raw=payload,
+        )
+
+    def download(self, **options):
+        url = options.get("url")
+        if not url:
+            server = options.get("server")
+            file_id = options.get("file_id")
+            filename = options.get("filename")
+            if not all([server, file_id, filename]):
+                raise ProviderError(self.info.name, "Provide url or server, file_id, and filename")
+            url = f"https://{server}.gofile.io/download/{file_id}/{filename}"
+        try:
+            response = self.http.get(url)
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._json_response(response)
+
+
+class AnonFilesNewProvider(BaseProvider):
+    info = ProviderInfo(
+        name="anonfilesnew",
+        display_name="AnonFilesNew",
+        supports_info=True,
+        requires_api_key=True,
+    )
+
+    def upload(self, filepath, **options):
+        api_key = options.get("api_key") or os.environ.get(options.get("api_key_env") or "ANONFILESNEW_API_KEY")
+        url = "https://api.anonfilesnew.com/upload"
+        if api_key:
+            url = f"{url}?key={api_key}"
+        payload = self._post_file(url, filepath)
+        if not payload.get("status"):
+            error = payload.get("error", {})
+            raise ProviderError(self.info.name, error.get("message", "Upload failed"), code=error.get("type"))
+        file_data = payload.get("data", {}).get("file", {})
+        url_data = file_data.get("url", {})
+        metadata = file_data.get("metadata", {})
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=url_data.get("full"),
+            short_url=url_data.get("short"),
+            file_id=metadata.get("id"),
+            metadata=metadata,
+            raw=payload,
+        )
+
+    def info_file(self, file_id, **options):
+        try:
+            response = self.http.get(f"https://api.anonfilesnew.com/v3/file/{file_id}/info")
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._json_response(response)
+
+
+class JsonBinProvider(BaseProvider):
+    info = ProviderInfo(
+        name="jsonbin",
+        display_name="JSONBin",
+        supports_download=False,
+        supports_info=False,
+        requires_api_key=True,
+    )
+
+    def upload(self, filepath, **options):
+        path = self._ensure_file(filepath)
+        api_key = options.get("api_key") or os.environ.get(options.get("api_key_env") or "JSONBIN_API_KEYS")
+        if api_key and "," in api_key:
+            api_key = api_key.split(",", 1)[0].strip()
+        if not api_key:
+            raise ProviderError(self.info.name, "Provide a JSONBin API key", code="api_key_required")
+
+        data = path.read_bytes()
+        record = {
+            "upload_id": str(uuid.uuid4()),
+            "original_filename": path.name,
+            "file_size": len(data),
+            "file_sha256": hashlib.sha256(data).hexdigest(),
+            "uploaded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "content_encoding": "base64",
+            "content": base64.b64encode(data).decode("ascii"),
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "X-Master-Key": api_key,
+            "X-Bin-Private": "true",
+            "X-Bin-Name": path.name[:128],
+        }
+        try:
+            response = self.http.post("https://api.jsonbin.io/v3/b", headers=headers, json=record, timeout=60)
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        payload = self._json_response(response)
+        metadata = payload.get("metadata", {})
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=metadata.get("id"),
+            file_id=metadata.get("id"),
+            metadata=metadata,
+            raw=payload,
+        )
+
+
+class AnonFilesProvider(AnonFilesNewProvider):
+    info = ProviderInfo(
+        name="anonfiles",
+        display_name="AnonFiles",
+        supports_info=False,
+        deprecated=True,
+    )
+
+    def upload(self, filepath, **options):
+        payload = self._post_file("https://api.anonfiles.com/upload", filepath)
+        if not payload.get("status"):
+            error = payload.get("error", {})
+            raise ProviderError(self.info.name, error.get("message", "Upload failed"), code=error.get("type"))
+        file_data = payload.get("data", {}).get("file", {})
+        url_data = file_data.get("url", {})
+        metadata = file_data.get("metadata", {})
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=url_data.get("full"),
+            short_url=url_data.get("short"),
+            file_id=metadata.get("id"),
+            metadata=metadata,
+            raw=payload,
+        )
+
+
+class BayFilesProvider(AnonFilesProvider):
+    info = ProviderInfo(
+        name="bayfiles",
+        display_name="BayFiles",
+        supports_info=False,
+        deprecated=True,
+    )
+
+    def upload(self, filepath, **options):
+        payload = self._post_file("https://api.bayfiles.com/upload", filepath)
+        if not payload.get("status"):
+            error = payload.get("error", {})
+            raise ProviderError(self.info.name, error.get("message", "Upload failed"), code=error.get("type"))
+        file_data = payload.get("data", {}).get("file", {})
+        url_data = file_data.get("url", {})
+        metadata = file_data.get("metadata", {})
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=url_data.get("full"),
+            short_url=url_data.get("short"),
+            file_id=metadata.get("id"),
+            metadata=metadata,
+            raw=payload,
+        )

--- a/fileuploader/registry.py
+++ b/fileuploader/registry.py
@@ -1,0 +1,40 @@
+from .models import ProviderError
+from .providers import (
+    AnonFilesNewProvider,
+    AnonFilesProvider,
+    BayFilesProvider,
+    GoFileProvider,
+    JsonBinProvider,
+)
+
+
+class ProviderRegistry:
+    def __init__(self, providers=None):
+        self._providers = {}
+        for provider in providers or []:
+            self.register(provider)
+
+    def register(self, provider):
+        self._providers[provider.info.name] = provider
+
+    def get(self, name):
+        try:
+            return self._providers[name]
+        except KeyError as exc:
+            choices = ", ".join(sorted(self._providers))
+            raise ProviderError(name, f"Unknown provider '{name}'. Available providers: {choices}") from exc
+
+    def providers(self):
+        return [self._providers[name] for name in sorted(self._providers)]
+
+
+def create_default_registry():
+    return ProviderRegistry(
+        [
+            GoFileProvider(),
+            AnonFilesNewProvider(),
+            JsonBinProvider(),
+            AnonFilesProvider(),
+            BayFilesProvider(),
+        ]
+    )

--- a/tests/test_provider_core.py
+++ b/tests/test_provider_core.py
@@ -1,0 +1,96 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from fileuploader import FileUploaderCore, ProviderError, create_default_registry
+from fileuploader.providers import AnonFilesNewProvider, GoFileProvider
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self.payload
+
+
+class FakeHttp:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append(("post", url, kwargs))
+        return FakeResponse(self.payload)
+
+    def get(self, url, **kwargs):
+        self.calls.append(("get", url, kwargs))
+        return FakeResponse(self.payload)
+
+
+class ProviderCoreTests(unittest.TestCase):
+    def test_registry_lists_active_and_deprecated_services(self):
+        services = FileUploaderCore(create_default_registry()).services()
+        names = {service.name for service in services}
+
+        self.assertEqual({"anonfiles", "anonfilesnew", "bayfiles", "gofile", "jsonbin"}, names)
+        self.assertTrue(any(service.deprecated for service in services if service.name == "anonfiles"))
+        self.assertTrue(any(service.deprecated for service in services if service.name == "bayfiles"))
+
+    def test_unknown_provider_raises_normalized_error(self):
+        with self.assertRaises(ProviderError) as error:
+            FileUploaderCore(create_default_registry()).upload("missing", "file.txt")
+
+        self.assertEqual(error.exception.provider, "missing")
+        self.assertIn("Unknown provider", error.exception.message)
+
+    def test_gofile_upload_normalizes_result(self):
+        payload = {
+            "status": "ok",
+            "data": {
+                "downloadPage": "https://gofile.io/d/abc",
+                "fileId": "file-1",
+                "fileName": "sample.txt",
+            },
+        }
+        provider = GoFileProvider(http_client=FakeHttp(payload))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source)
+
+        self.assertTrue(result.status)
+        self.assertEqual(result.provider, "gofile")
+        self.assertEqual(result.url, "https://gofile.io/d/abc")
+        self.assertEqual(result.file_id, "file-1")
+
+    def test_anonfilesnew_upload_normalizes_result_and_api_key(self):
+        payload = {
+            "status": True,
+            "data": {
+                "file": {
+                    "url": {"full": "https://anonfilesnew.com/full", "short": "https://anonfilesnew.com/s"},
+                    "metadata": {"id": "file-1", "name": "sample.txt"},
+                }
+            },
+        }
+        http = FakeHttp(payload)
+        provider = AnonFilesNewProvider(http_client=http)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source, api_key="secret")
+
+        self.assertEqual(result.provider, "anonfilesnew")
+        self.assertEqual(result.file_id, "file-1")
+        self.assertEqual(result.short_url, "https://anonfilesnew.com/s")
+        self.assertIn("?key=secret", http.calls[0][1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a shared `fileuploader` provider core with normalized provider metadata, upload results, and provider errors.
- Registers GoFile, AnonFilesNew, JSONBin, AnonFiles, and BayFiles behind a common interface.
- Keeps deprecated providers available while surfacing clear normalized errors.
- Adds provider-core unit tests with mocked HTTP clients and no network dependency.

## Validation

- `python -m unittest tests.test_provider_core tests.test_gofile_encryption tests.test_jsonbin_uploader`
- `python -m py_compile fileuploader\__init__.py fileuploader\models.py fileuploader\core.py fileuploader\registry.py fileuploader\providers.py tests\test_provider_core.py`

Closes #10.