### PR TITLE
Add Rich TUI

### DIFF
--- a/fileuploader_tui.py
+++ b/fileuploader_tui.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+
+from fileuploader import FileUploaderCore
+from fileuploader.formatting import format_output
+from fileuploader.models import ProviderError
+
+
+@dataclass
+class TuiRequest:
+    service: str
+    action: str
+    path: str = ""
+    url: str = ""
+    file_id: str = ""
+    api_key: str = ""
+    api_key_env: str = ""
+    json_output: bool = False
+
+
+def service_table(core=None) -> Table:
+    core = core or FileUploaderCore()
+    table = Table(title="FileUploader Services")
+    table.add_column("Name")
+    table.add_column("Display")
+    table.add_column("Upload")
+    table.add_column("Download")
+    table.add_column("Info")
+    table.add_column("Deprecated")
+    for service in core.services(include_deprecated=True):
+        table.add_row(
+            service.name,
+            service.display_name,
+            "yes" if service.supports_upload else "no",
+            "yes" if service.supports_download else "no",
+            "yes" if service.supports_info else "no",
+            "yes" if service.deprecated else "no",
+        )
+    return table
+
+
+def request_options(request: TuiRequest) -> dict:
+    return {
+        "api_key": request.api_key or None,
+        "api_key_env": request.api_key_env or None,
+        "url": request.url or None,
+    }
+
+
+class FileUploaderTui:
+    def __init__(self, core=None, console=None):
+        self.core = core or FileUploaderCore()
+        self.console = console or Console()
+
+    def run_once(self, request: TuiRequest):
+        try:
+            if request.action == "upload":
+                result = self.core.upload(request.service, request.path, **request_options(request))
+            elif request.action == "download":
+                result = self.core.download(request.service, **request_options(request))
+            elif request.action == "info":
+                result = self.core.info(request.service, request.file_id, **request_options(request))
+            else:
+                raise ProviderError(request.service, f"Unknown action: {request.action}")
+            if hasattr(result, "to_dict"):
+                result = result.to_dict()
+            return {"ok": True, "result": result}
+        except ProviderError as exc:
+            return {"ok": False, "error": exc.to_dict()}
+
+    def interactive(self):
+        self.console.print(Panel.fit("FileUploader TUI"))
+        self.console.print(service_table(self.core))
+        services = [service.name for service in self.core.services(include_deprecated=True)]
+        while True:
+            service = Prompt.ask("Service", choices=services, default=services[0])
+            action = Prompt.ask("Action", choices=["upload", "download", "info"], default="upload")
+            path = Prompt.ask("File path", default="") if action == "upload" else ""
+            url = Prompt.ask("URL", default="") if action == "download" else ""
+            file_id = Prompt.ask("File ID", default="") if action == "info" else ""
+            api_key = Prompt.ask("API key", password=True, default="")
+            api_key_env = Prompt.ask("API key env var", default="")
+            json_output = Confirm.ask("JSON output?", default=False)
+
+            payload = self.run_once(
+                TuiRequest(
+                    service=service,
+                    action=action,
+                    path=path,
+                    url=url,
+                    file_id=file_id,
+                    api_key=api_key,
+                    api_key_env=api_key_env,
+                    json_output=json_output,
+                )
+            )
+            self.console.print(Panel(format_output(payload, json_output=json_output), title="Result"))
+            if not Confirm.ask("Run another action?", default=False):
+                break
+
+
+def main():
+    FileUploaderTui().interactive()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ idna==3.6
 lxml==4.9.3
 pycparser==2.21
 requests==2.31.0
+rich==13.9.4
 typer==0.12.5
 urllib3==2.1.0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,37 @@
+import unittest
+
+from fileuploader.models import ProviderInfo, UploadResult
+from fileuploader_tui import FileUploaderTui, TuiRequest, request_options, service_table
+
+
+class FakeCore:
+    def services(self, include_deprecated=True):
+        return [ProviderInfo(name="gofile", display_name="GoFile")]
+
+    def upload(self, service, path, **options):
+        return UploadResult(provider=service, status=True, url="https://example.test", file_id="file-1")
+
+
+class TuiSmokeTests(unittest.TestCase):
+    def test_request_options_converts_empty_strings(self):
+        options = request_options(TuiRequest(service="gofile", action="upload"))
+
+        self.assertIsNone(options["api_key"])
+        self.assertIsNone(options["api_key_env"])
+        self.assertIsNone(options["url"])
+
+    def test_service_table_contains_provider_rows(self):
+        table = service_table(FakeCore())
+
+        self.assertEqual(len(table.rows), 1)
+
+    def test_run_once_returns_normalized_result(self):
+        tui = FileUploaderTui(core=FakeCore())
+        result = tui.run_once(TuiRequest(service="gofile", action="upload", path="sample.txt"))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["result"]["provider"], "gofile")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `python -m fileuploader_tui` as a Rich-powered terminal UI.
- Lists providers in a table and supports upload, download, and info flows.
- Displays normalized results in terminal panels.
- Adds TUI smoke tests without network access.

## Validation

- `python -m unittest tests.test_tui tests.test_gui tests.test_cli tests.test_provider_core tests.test_gofile_encryption tests.test_jsonbin_uploader`
- `python -m py_compile fileuploader_tui.py tests\test_tui.py`
- `python -c "from fileuploader_tui import service_table; print(len(service_table().rows))"`

Closes #13.