### PR TITLE
Improve interface usability

### DIFF
--- a/fileuploader/cli.py
+++ b/fileuploader/cli.py
@@ -3,12 +3,17 @@ from typing import Optional
 
 import typer
 
+from .clipboard import copy_text
 from .core import FileUploaderCore
-from .formatting import format_output
+from .formatting import format_output, service_rows
 from .models import ProviderError
+from .validation import require_value
 
 
-app = typer.Typer(help="Unified file uploader for supported hosting providers.")
+app = typer.Typer(
+    help="Upload files with GoFile, AnonFilesNew, JSONBin, AnonFiles, or BayFiles.",
+    no_args_is_help=True,
+)
 
 
 def _resolve_api_key(api_key: Optional[str], api_key_env: Optional[str]) -> Optional[str]:
@@ -36,14 +41,15 @@ def services(
 ):
     """List available providers."""
     result = FileUploaderCore().services(include_deprecated=include_deprecated)
-    _print_result([service.to_dict() for service in result], json_output)
+    services_data = [service.to_dict() for service in result]
+    typer.echo(format_output(services_data, json_output=True) if json_output else service_rows(services_data))
 
 
 @app.command()
 def upload(
-    path: str = typer.Argument(..., help="File path to upload."),
-    service: str = typer.Option(..., "--service", "-s", help="Provider name."),
-    api_key: Optional[str] = typer.Option(None, "--api-key", help="Provider API key."),
+    path: str = typer.Argument(..., help="File path to upload, for example ./document.pdf."),
+    service: str = typer.Option(..., "--service", "-s", help="Provider name. Run `services` to list choices."),
+    api_key: Optional[str] = typer.Option(None, "--api-key", help="Provider API key. Prefer --api-key-env for repeat use."),
     api_key_env: Optional[str] = typer.Option(None, "--api-key-env", help="Environment variable that contains the API key."),
     json_output: bool = typer.Option(False, "--json", help="Print JSON output."),
     plaintext: bool = typer.Option(False, "--plaintext", help="Print plaintext output."),
@@ -52,6 +58,7 @@ def upload(
 ):
     """Upload a file with a provider."""
     try:
+        require_value(service, path, "Provide a file path to upload.", "path_required")
         result = FileUploaderCore().upload(
             service,
             path,
@@ -66,12 +73,16 @@ def upload(
     output = format_output(result.to_dict(), json_output=json_output and not plaintext)
     typer.echo(output)
     if copy:
-        typer.echo("Clipboard copy is available in the GoFile legacy command and GUI.")
+        try:
+            copy_text(output)
+            typer.echo("Copied result to clipboard.")
+        except Exception as exc:
+            typer.echo(f"Could not copy result to clipboard: {exc}", err=True)
 
 
 @app.command()
 def download(
-    service: str = typer.Option(..., "--service", "-s", help="Provider name."),
+    service: str = typer.Option(..., "--service", "-s", help="Provider name. GoFile supports download metadata."),
     url: Optional[str] = typer.Option(None, "--url", help="Direct download URL."),
     server: Optional[str] = typer.Option(None, "--server", help="Provider server."),
     file_id: Optional[str] = typer.Option(None, "--file-id", help="Provider file id."),
@@ -81,6 +92,8 @@ def download(
 ):
     """Download or fetch download metadata."""
     try:
+        if not url and not all([server, file_id, filename]):
+            raise ProviderError(service, "Provide --url or --server, --file-id, and --filename.", code="download_target_required")
         result = FileUploaderCore().download(
             service,
             url=url,
@@ -98,13 +111,14 @@ def download(
 @app.command()
 def info(
     file_id: str = typer.Argument(..., help="Provider file id."),
-    service: str = typer.Option(..., "--service", "-s", help="Provider name."),
+    service: str = typer.Option(..., "--service", "-s", help="Provider name. AnonFilesNew supports info."),
     api_key: Optional[str] = typer.Option(None, "--api-key", help="Provider API key."),
     api_key_env: Optional[str] = typer.Option(None, "--api-key-env", help="Environment variable that contains the API key."),
     json_output: bool = typer.Option(False, "--json", help="Print JSON output."),
 ):
     """Fetch provider file metadata."""
     try:
+        require_value(service, file_id, "Provide the provider file id.", "file_id_required")
         result = FileUploaderCore().info(
             service,
             file_id,

--- a/fileuploader/clipboard.py
+++ b/fileuploader/clipboard.py
@@ -1,0 +1,9 @@
+def copy_text(text: str) -> None:
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.withdraw()
+    root.clipboard_clear()
+    root.clipboard_append(text)
+    root.update()
+    root.destroy()

--- a/fileuploader/formatting.py
+++ b/fileuploader/formatting.py
@@ -3,6 +3,32 @@ from dataclasses import asdict, is_dataclass
 from typing import Any
 
 
+def service_rows(services: list[dict[str, Any]]) -> str:
+    headers = ["Service", "Upload", "Download", "Info", "API key", "Status"]
+    rows = []
+    for service in services:
+        rows.append(
+            [
+                service["name"],
+                "yes" if service["supports_upload"] else "no",
+                "yes" if service["supports_download"] else "no",
+                "yes" if service["supports_info"] else "no",
+                "yes" if service["requires_api_key"] else "no",
+                "deprecated" if service["deprecated"] else "active",
+            ]
+        )
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for index, value in enumerate(row):
+            widths[index] = max(widths[index], len(value))
+
+    def render_row(values):
+        return "  ".join(value.ljust(widths[index]) for index, value in enumerate(values))
+
+    separator = "  ".join("-" * width for width in widths)
+    return "\n".join([render_row(headers), separator, *[render_row(row) for row in rows]])
+
+
 def to_plaintext(value: Any, indent: int = 0) -> str:
     if is_dataclass(value):
         value = asdict(value)

--- a/fileuploader/registry.py
+++ b/fileuploader/registry.py
@@ -15,11 +15,12 @@ class ProviderRegistry:
             self.register(provider)
 
     def register(self, provider):
-        self._providers[provider.info.name] = provider
+        self._providers[provider.info.name.lower()] = provider
 
     def get(self, name):
+        normalized_name = name.lower()
         try:
-            return self._providers[name]
+            return self._providers[normalized_name]
         except KeyError as exc:
             choices = ", ".join(sorted(self._providers))
             raise ProviderError(name, f"Unknown provider '{name}'. Available providers: {choices}") from exc

--- a/fileuploader/validation.py
+++ b/fileuploader/validation.py
@@ -1,0 +1,6 @@
+from .models import ProviderError
+
+
+def require_value(provider: str, value: str | None, message: str, code: str):
+    if not value:
+        raise ProviderError(provider, message, code=code)

--- a/fileuploader_gui.py
+++ b/fileuploader_gui.py
@@ -31,12 +31,21 @@ def build_options(state: GuiState) -> dict:
     }
 
 
+def validate_state(state: GuiState) -> None:
+    if state.action == "upload" and not state.path:
+        raise ProviderError(state.service, "Choose a file before uploading.", code="path_required")
+    if state.action == "download" and not state.url:
+        raise ProviderError(state.service, "Enter a download URL before downloading.", code="url_required")
+    if state.action == "info" and not state.file_id:
+        raise ProviderError(state.service, "Enter a file id before requesting info.", code="file_id_required")
+
+
 class FileUploaderGui:
     def __init__(self, root, core=None):
         self.root = root
         self.core = core or FileUploaderCore()
         self.root.title("FileUploader")
-        self.root.geometry("760x560")
+        self.root.geometry("840x620")
         self.services = self.core.services(include_deprecated=True)
         self.service_names = [service.name for service in self.services]
         self._build_widgets()
@@ -44,6 +53,11 @@ class FileUploaderGui:
     def _build_widgets(self):
         container = ttk.Frame(self.root, padding=12)
         container.pack(fill="both", expand=True)
+
+        ttk.Label(
+            container,
+            text="Choose a provider, action, and the required fields. Results appear below and can be copied.",
+        ).pack(fill="x", pady=(0, 10))
 
         controls = ttk.Frame(container)
         controls.pack(fill="x")
@@ -79,8 +93,11 @@ class FileUploaderGui:
 
         self.json_var = tk.BooleanVar(value=False)
         ttk.Checkbutton(controls, text="JSON output", variable=self.json_var).grid(row=5, column=1, sticky="w", padx=6)
-        ttk.Button(controls, text="Run", command=self._run_action).grid(row=5, column=2, sticky="ew", padx=6, pady=8)
+        ttk.Button(controls, text="Run action", command=self._run_action).grid(row=5, column=2, sticky="ew", padx=6, pady=8)
         ttk.Button(controls, text="Copy result", command=self._copy_result).grid(row=5, column=3, sticky="ew", padx=6, pady=8)
+
+        self.hint_var = tk.StringVar(value="Upload: choose a file. Download: enter URL. Info: enter file id.")
+        ttk.Label(controls, textvariable=self.hint_var).grid(row=6, column=0, columnspan=4, sticky="w", pady=(2, 0))
 
         controls.columnconfigure(1, weight=1)
         controls.columnconfigure(3, weight=1)
@@ -112,6 +129,7 @@ class FileUploaderGui:
     def _run_action(self):
         state = self._state()
         try:
+            validate_state(state)
             if state.action == "upload":
                 result = self.core.upload(state.service, state.path, **build_options(state))
             elif state.action == "download":

--- a/fileuploader_tui.py
+++ b/fileuploader_tui.py
@@ -51,6 +51,15 @@ def request_options(request: TuiRequest) -> dict:
     }
 
 
+def validate_request(request: TuiRequest) -> None:
+    if request.action == "upload" and not request.path:
+        raise ProviderError(request.service, "Provide a file path to upload.", code="path_required")
+    if request.action == "download" and not request.url:
+        raise ProviderError(request.service, "Provide a download URL.", code="url_required")
+    if request.action == "info" and not request.file_id:
+        raise ProviderError(request.service, "Provide a file id.", code="file_id_required")
+
+
 class FileUploaderTui:
     def __init__(self, core=None, console=None):
         self.core = core or FileUploaderCore()
@@ -58,6 +67,7 @@ class FileUploaderTui:
 
     def run_once(self, request: TuiRequest):
         try:
+            validate_request(request)
             if request.action == "upload":
                 result = self.core.upload(request.service, request.path, **request_options(request))
             elif request.action == "download":
@@ -73,17 +83,17 @@ class FileUploaderTui:
             return {"ok": False, "error": exc.to_dict()}
 
     def interactive(self):
-        self.console.print(Panel.fit("FileUploader TUI"))
+        self.console.print(Panel.fit("FileUploader TUI\nPick a provider, choose an action, then fill only the fields requested."))
         self.console.print(service_table(self.core))
         services = [service.name for service in self.core.services(include_deprecated=True)]
         while True:
             service = Prompt.ask("Service", choices=services, default=services[0])
             action = Prompt.ask("Action", choices=["upload", "download", "info"], default="upload")
-            path = Prompt.ask("File path", default="") if action == "upload" else ""
-            url = Prompt.ask("URL", default="") if action == "download" else ""
-            file_id = Prompt.ask("File ID", default="") if action == "info" else ""
-            api_key = Prompt.ask("API key", password=True, default="")
-            api_key_env = Prompt.ask("API key env var", default="")
+            path = Prompt.ask("File path to upload", default="") if action == "upload" else ""
+            url = Prompt.ask("Download URL", default="") if action == "download" else ""
+            file_id = Prompt.ask("Provider file ID", default="") if action == "info" else ""
+            api_key = Prompt.ask("API key, leave blank if not needed", password=True, default="")
+            api_key_env = Prompt.ask("API key environment variable, leave blank if not needed", default="")
             json_output = Confirm.ask("JSON output?", default=False)
 
             payload = self.run_once(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,15 @@ class CliTests(unittest.TestCase):
         self.assertEqual({"gofile", "bayfiles"}, {item["name"] for item in payload})
 
     @patch("fileuploader.cli.FileUploaderCore", return_value=FakeCore())
+    def test_services_default_output_is_readable_table(self, _core):
+        result = self.runner.invoke(app, ["services"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Service", result.output)
+        self.assertIn("gofile", result.output)
+        self.assertIn("deprecated", result.output)
+
+    @patch("fileuploader.cli.FileUploaderCore", return_value=FakeCore())
     def test_upload_outputs_json(self, _core):
         result = self.runner.invoke(app, ["upload", "sample.txt", "--service", "gofile", "--json"])
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,6 +1,7 @@
 import unittest
 
-from fileuploader_gui import GuiState, build_options, default_state
+from fileuploader.models import ProviderError
+from fileuploader_gui import GuiState, build_options, default_state, validate_state
 
 
 class GuiSmokeTests(unittest.TestCase):
@@ -23,6 +24,12 @@ class GuiSmokeTests(unittest.TestCase):
         self.assertEqual(options["api_key"], "key")
         self.assertEqual(options["api_key_env"], "KEY_ENV")
         self.assertEqual(options["url"], "https://example.test")
+
+    def test_validate_state_requires_upload_file(self):
+        with self.assertRaises(ProviderError) as error:
+            validate_state(GuiState(action="upload", path=""))
+
+        self.assertEqual(error.exception.code, "path_required")
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_core.py
+++ b/tests/test_provider_core.py
@@ -47,6 +47,11 @@ class ProviderCoreTests(unittest.TestCase):
         self.assertEqual(error.exception.provider, "missing")
         self.assertIn("Unknown provider", error.exception.message)
 
+    def test_provider_lookup_is_case_insensitive(self):
+        provider = create_default_registry().get("GoFile")
+
+        self.assertEqual(provider.info.name, "gofile")
+
     def test_gofile_upload_normalizes_result(self):
         payload = {
             "status": "ok",

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,7 +1,7 @@
 import unittest
 
-from fileuploader.models import ProviderInfo, UploadResult
-from fileuploader_tui import FileUploaderTui, TuiRequest, request_options, service_table
+from fileuploader.models import ProviderError, ProviderInfo, UploadResult
+from fileuploader_tui import FileUploaderTui, TuiRequest, request_options, service_table, validate_request
 
 
 class FakeCore:
@@ -31,6 +31,12 @@ class TuiSmokeTests(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         self.assertEqual(result["result"]["provider"], "gofile")
+
+    def test_validate_request_requires_upload_path(self):
+        with self.assertRaises(ProviderError) as error:
+            validate_request(TuiRequest(service="gofile", action="upload"))
+
+        self.assertEqual(error.exception.code, "path_required")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Makes provider lookup case-insensitive and keeps unknown-provider errors actionable with available choices.
- Makes `python -m fileuploader services` render a readable table by default while preserving `--json` output.
- Adds real clipboard copying for the unified CLI `--copy` option.
- Adds preflight validation for CLI, GUI, and TUI inputs so users get clear field-specific errors before provider calls.
- Improves GUI/TUI wording and prompts so required fields are easier to understand.
- Adds tests for provider lookup, service table output, and GUI/TUI validation.

## Validation

- `python -m unittest discover -s tests`
- `python -m py_compile fileuploader\__init__.py fileuploader\__main__.py fileuploader\cli.py fileuploader\clipboard.py fileuploader\core.py fileuploader\formatting.py fileuploader\models.py fileuploader\providers.py fileuploader\registry.py fileuploader\validation.py fileuploader_gui.py fileuploader_tui.py`
- `python -m fileuploader services`
- `python -m fileuploader upload missing.txt --service nope --json` returns a normalized actionable error.

Closes #20.