### PR TITLE
Add guided CLI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ List all providers:
 python -m fileuploader services
 ```
 
+Use the guided CLI when you do not remember the flags:
+
+```shell
+python -m fileuploader guided
+```
+
 Upload a file with GoFile and print JSON:
 
 ```shell
@@ -76,6 +82,7 @@ python -m fileuploader_tui
 
 ```shell
 python -m fileuploader services [--json] [--active-only]
+python -m fileuploader guided
 python -m fileuploader upload PATH --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json] [--plaintext] [--copy] [--verbose]
 python -m fileuploader download --service SERVICE [--url URL] [--server SERVER --file-id FILE_ID --filename NAME] [--json]
 python -m fileuploader info FILE_ID --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json]

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -12,9 +12,12 @@ The primary CLI is built with Typer:
 
 ```shell
 python -m fileuploader services
+python -m fileuploader guided
 python -m fileuploader upload --service gofile path/to/file.txt --json
 python -m fileuploader info --service anonfilesnew FILE_ID --api-key YOUR_API_KEY
 ```
+
+Use `python -m fileuploader guided` for a step-by-step flow that shows providers, asks for an action, and prompts only for the fields needed by that action.
 
 Typer is used because it provides a modern command surface while building on Click internally. Click is therefore covered as the underlying command framework. The older argparse scripts remain available as legacy provider-specific entrypoints, but new automation should use `python -m fileuploader`.
 

--- a/fileuploader/cli.py
+++ b/fileuploader/cli.py
@@ -34,6 +34,25 @@ def _exit_provider_error(error: ProviderError, json_output: bool):
     raise typer.Exit(code=1)
 
 
+def _service_names(core: FileUploaderCore) -> list[str]:
+    return [service.name for service in core.services(include_deprecated=True)]
+
+
+def build_guided_upload(core: FileUploaderCore, service: str, path: str, api_key: Optional[str], api_key_env: Optional[str]):
+    require_value(service, path, "Provide a file path to upload.", "path_required")
+    return core.upload(service, path, api_key=_resolve_api_key(api_key, api_key_env), api_key_env=api_key_env)
+
+
+def build_guided_download(core: FileUploaderCore, service: str, url: str):
+    require_value(service, url, "Provide a download URL.", "url_required")
+    return core.download(service, url=url)
+
+
+def build_guided_info(core: FileUploaderCore, service: str, file_id: str, api_key: Optional[str], api_key_env: Optional[str]):
+    require_value(service, file_id, "Provide the provider file id.", "file_id_required")
+    return core.info(service, file_id, api_key=_resolve_api_key(api_key, api_key_env), api_key_env=api_key_env)
+
+
 @app.command()
 def services(
     json_output: bool = typer.Option(False, "--json", help="Print JSON output."),
@@ -43,6 +62,46 @@ def services(
     result = FileUploaderCore().services(include_deprecated=include_deprecated)
     services_data = [service.to_dict() for service in result]
     typer.echo(format_output(services_data, json_output=True) if json_output else service_rows(services_data))
+
+
+@app.command()
+def guided():
+    """Run a step-by-step upload, download, or info flow."""
+    core = FileUploaderCore()
+    services_data = [service.to_dict() for service in core.services(include_deprecated=True)]
+    typer.echo("Available providers:")
+    typer.echo(service_rows(services_data))
+
+    service = typer.prompt("Provider", default=services_data[0]["name"])
+    action = typer.prompt("Action", default="upload")
+    api_key = None
+    api_key_env = None
+    json_output = typer.confirm("Print JSON output?", default=False)
+
+    try:
+        if action == "upload":
+            path = typer.prompt("File path to upload")
+            api_key = typer.prompt("API key, leave blank if not needed", default="")
+            api_key_env = typer.prompt("API key environment variable, leave blank if not needed", default="")
+            result = build_guided_upload(core, service, path, api_key or None, api_key_env or None)
+        elif action == "download":
+            url = typer.prompt("Download URL")
+            result = build_guided_download(core, service, url)
+        elif action == "info":
+            file_id = typer.prompt("Provider file ID")
+            api_key = typer.prompt("API key, leave blank if not needed", default="")
+            api_key_env = typer.prompt("API key environment variable, leave blank if not needed", default="")
+            result = build_guided_info(core, service, file_id, api_key or None, api_key_env or None)
+        else:
+            choices = "upload, download, info"
+            raise ProviderError(service, f"Unknown action '{action}'. Choose one of: {choices}", code="unknown_action")
+    except ProviderError as error:
+        _exit_provider_error(error, json_output)
+        return
+
+    if hasattr(result, "to_dict"):
+        result = result.to_dict()
+    _print_result(result, json_output)
 
 
 @app.command()

--- a/fileuploader/providers.py
+++ b/fileuploader/providers.py
@@ -68,7 +68,7 @@ class GoFileProvider(BaseProvider):
             provider=self.info.name,
             status=True,
             url=data.get("downloadPage"),
-            file_id=data.get("fileId") or data.get("code"),
+            file_id=data.get("fileId") or data.get("id") or data.get("code") or data.get("parentFolderCode"),
             metadata=data,
             raw=payload,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from fileuploader.cli import app
+from fileuploader.cli import app, build_guided_download, build_guided_info, build_guided_upload
 from fileuploader.models import ProviderError, ProviderInfo, UploadResult
 
 
@@ -65,6 +65,30 @@ class CliTests(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["error"]["provider"], "missing")
+
+    @patch("fileuploader.cli.FileUploaderCore", return_value=FakeCore())
+    def test_guided_upload_flow(self, _core):
+        result = self.runner.invoke(
+            app,
+            ["guided"],
+            input="gofile\nupload\nn\nsample.txt\n\n\n",
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("https://example.test/file", result.output)
+
+    def test_guided_helpers_validate_missing_values(self):
+        with self.assertRaises(ProviderError) as error:
+            build_guided_upload(FakeCore(), "gofile", "", None, None)
+        self.assertEqual(error.exception.code, "path_required")
+
+        with self.assertRaises(ProviderError) as error:
+            build_guided_download(FakeCore(), "gofile", "")
+        self.assertEqual(error.exception.code, "url_required")
+
+        with self.assertRaises(ProviderError) as error:
+            build_guided_info(FakeCore(), "gofile", "", None, None)
+        self.assertEqual(error.exception.code, "file_id_required")
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_core.py
+++ b/tests/test_provider_core.py
@@ -57,7 +57,7 @@ class ProviderCoreTests(unittest.TestCase):
             "status": "ok",
             "data": {
                 "downloadPage": "https://gofile.io/d/abc",
-                "fileId": "file-1",
+                "id": "file-1",
                 "fileName": "sample.txt",
             },
         }


### PR DESCRIPTION
## Summary

- Adds `python -m fileuploader guided` as a step-by-step CLI workflow.
- Shows available providers before prompting.
- Prompts only for fields needed by upload, download, or info.
- Reuses the same normalized outputs and provider errors as direct commands.
- Documents the guided flow in README and interface docs.
- Adds tests for guided flow execution and validation helpers.
- Fixes GoFile upload normalization so current API responses populate `file_id` from the returned `id` field.

## Validation

- `python -m unittest discover -s tests`
- `python -m py_compile fileuploader\__init__.py fileuploader\__main__.py fileuploader\cli.py fileuploader\clipboard.py fileuploader\core.py fileuploader\formatting.py fileuploader\models.py fileuploader\providers.py fileuploader\registry.py fileuploader\validation.py fileuploader_gui.py fileuploader_tui.py`
- `python -m fileuploader services`
- `python -m fileuploader --help`
- Piped guided smoke test with missing file returns a clear normalized provider error.
- Real GoFile CLI upload returned a valid `https://gofile.io/d/...` URL and populated `file_id`.

Closes #22.