### PR TITLE
Make GUI provider-aware

### DIFF
--- a/fileuploader_gui.py
+++ b/fileuploader_gui.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from dataclasses import dataclass
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, font, messagebox, ttk
 
 from fileuploader import FileUploaderCore
 from fileuploader.formatting import format_output
@@ -31,13 +31,67 @@ def build_options(state: GuiState) -> dict:
     }
 
 
-def validate_state(state: GuiState) -> None:
+def active_services(services):
+    return [service for service in services if not service.deprecated]
+
+
+def deprecated_services(services):
+    return [service for service in services if service.deprecated]
+
+
+def service_names(services):
+    return [service.name for service in services]
+
+
+def default_service_name(services):
+    names = service_names(active_services(services))
+    if "gofile" in names:
+        return "gofile"
+    return names[0] if names else ""
+
+
+def service_by_name(services, name):
+    for service in services:
+        if service.name == name:
+            return service
+    raise ProviderError(name, f"Unknown provider: {name}", code="unknown_provider")
+
+
+def actions_for_service(service):
+    actions = []
+    if service.supports_upload:
+        actions.append("upload")
+    if service.supports_download:
+        actions.append("download")
+    if service.supports_info:
+        actions.append("info")
+    return actions
+
+
+def required_fields_for_state(state: GuiState, service) -> set[str]:
+    fields = set()
+    if state.action == "upload":
+        fields.add("path")
+    elif state.action == "download":
+        fields.add("url")
+    elif state.action == "info":
+        fields.add("file_id")
+    if service.requires_api_key:
+        fields.add("api_key")
+    return fields
+
+
+def validate_state(state: GuiState, service=None) -> None:
+    if service and state.action not in actions_for_service(service):
+        raise ProviderError(state.service, f"{service.display_name} does not support {state.action}.", code="unsupported_action")
     if state.action == "upload" and not state.path:
         raise ProviderError(state.service, "Choose a file before uploading.", code="path_required")
     if state.action == "download" and not state.url:
         raise ProviderError(state.service, "Enter a download URL before downloading.", code="url_required")
     if state.action == "info" and not state.file_id:
         raise ProviderError(state.service, "Enter a file id before requesting info.", code="file_id_required")
+    if service and service.requires_api_key and not (state.api_key or state.api_key_env):
+        raise ProviderError(state.service, "Enter an API key or API key environment variable.", code="api_key_required")
 
 
 class FileUploaderGui:
@@ -45,9 +99,10 @@ class FileUploaderGui:
         self.root = root
         self.core = core or FileUploaderCore()
         self.root.title("FileUploader")
-        self.root.geometry("840x620")
+        self.root.geometry("920x680")
         self.services = self.core.services(include_deprecated=True)
-        self.service_names = [service.name for service in self.services]
+        self.active_service_names = service_names(active_services(self.services))
+        self.service_lookup = {service.name: service for service in self.services}
         self._build_widgets()
 
     def _build_widgets(self):
@@ -62,34 +117,49 @@ class FileUploaderGui:
         controls = ttk.Frame(container)
         controls.pack(fill="x")
 
-        ttk.Label(controls, text="Service").grid(row=0, column=0, sticky="w")
-        self.service_var = tk.StringVar(value=self.service_names[0] if self.service_names else "")
-        ttk.Combobox(controls, textvariable=self.service_var, values=self.service_names, state="readonly").grid(row=0, column=1, sticky="ew", padx=6)
+        ttk.Label(controls, text="Active service").grid(row=0, column=0, sticky="w")
+        self.service_var = tk.StringVar(value=default_service_name(self.services))
+        self.service_combo = ttk.Combobox(controls, textvariable=self.service_var, values=self.active_service_names, state="readonly")
+        self.service_combo.grid(row=0, column=1, sticky="ew", padx=6)
+        self.service_combo.bind("<<ComboboxSelected>>", lambda _event: self._sync_service_fields())
 
         ttk.Label(controls, text="Action").grid(row=0, column=2, sticky="w")
         self.action_var = tk.StringVar(value="upload")
-        ttk.Combobox(controls, textvariable=self.action_var, values=["upload", "download", "info"], state="readonly").grid(row=0, column=3, sticky="ew", padx=6)
+        self.action_combo = ttk.Combobox(controls, textvariable=self.action_var, values=["upload"], state="readonly")
+        self.action_combo.grid(row=0, column=3, sticky="ew", padx=6)
+        self.action_combo.bind("<<ComboboxSelected>>", lambda _event: self._sync_visible_fields())
 
-        ttk.Label(controls, text="File").grid(row=1, column=0, sticky="w", pady=6)
+        self.path_label = ttk.Label(controls, text="File")
+        self.path_label.grid(row=1, column=0, sticky="w", pady=6)
         self.path_var = tk.StringVar()
-        ttk.Entry(controls, textvariable=self.path_var).grid(row=1, column=1, columnspan=2, sticky="ew", padx=6)
-        ttk.Button(controls, text="Browse", command=self._browse_file).grid(row=1, column=3, sticky="ew", padx=6)
+        self.path_entry = ttk.Entry(controls, textvariable=self.path_var)
+        self.path_entry.grid(row=1, column=1, columnspan=2, sticky="ew", padx=6)
+        self.browse_button = ttk.Button(controls, text="Browse", command=self._browse_file)
+        self.browse_button.grid(row=1, column=3, sticky="ew", padx=6)
 
-        ttk.Label(controls, text="URL").grid(row=2, column=0, sticky="w", pady=6)
+        self.url_label = ttk.Label(controls, text="Download URL")
+        self.url_label.grid(row=2, column=0, sticky="w", pady=6)
         self.url_var = tk.StringVar()
-        ttk.Entry(controls, textvariable=self.url_var).grid(row=2, column=1, columnspan=3, sticky="ew", padx=6)
+        self.url_entry = ttk.Entry(controls, textvariable=self.url_var)
+        self.url_entry.grid(row=2, column=1, columnspan=3, sticky="ew", padx=6)
 
-        ttk.Label(controls, text="File ID").grid(row=3, column=0, sticky="w", pady=6)
+        self.file_id_label = ttk.Label(controls, text="File ID")
+        self.file_id_label.grid(row=3, column=0, sticky="w", pady=6)
         self.file_id_var = tk.StringVar()
-        ttk.Entry(controls, textvariable=self.file_id_var).grid(row=3, column=1, columnspan=3, sticky="ew", padx=6)
+        self.file_id_entry = ttk.Entry(controls, textvariable=self.file_id_var)
+        self.file_id_entry.grid(row=3, column=1, columnspan=3, sticky="ew", padx=6)
 
-        ttk.Label(controls, text="API Key").grid(row=4, column=0, sticky="w", pady=6)
+        self.api_key_label = ttk.Label(controls, text="API Key")
+        self.api_key_label.grid(row=4, column=0, sticky="w", pady=6)
         self.api_key_var = tk.StringVar()
-        ttk.Entry(controls, textvariable=self.api_key_var, show="*").grid(row=4, column=1, sticky="ew", padx=6)
+        self.api_key_entry = ttk.Entry(controls, textvariable=self.api_key_var, show="*")
+        self.api_key_entry.grid(row=4, column=1, sticky="ew", padx=6)
 
-        ttk.Label(controls, text="API Key Env").grid(row=4, column=2, sticky="w", pady=6)
+        self.api_key_env_label = ttk.Label(controls, text="API Key Env")
+        self.api_key_env_label.grid(row=4, column=2, sticky="w", pady=6)
         self.api_key_env_var = tk.StringVar()
-        ttk.Entry(controls, textvariable=self.api_key_env_var).grid(row=4, column=3, sticky="ew", padx=6)
+        self.api_key_env_entry = ttk.Entry(controls, textvariable=self.api_key_env_var)
+        self.api_key_env_entry.grid(row=4, column=3, sticky="ew", padx=6)
 
         self.json_var = tk.BooleanVar(value=False)
         ttk.Checkbutton(controls, text="JSON output", variable=self.json_var).grid(row=5, column=1, sticky="w", padx=6)
@@ -102,8 +172,69 @@ class FileUploaderGui:
         controls.columnconfigure(1, weight=1)
         controls.columnconfigure(3, weight=1)
 
+        self.deprecated_text = tk.Text(container, height=3, wrap="none", borderwidth=0)
+        self.deprecated_text.pack(fill="x", pady=(10, 0))
+        strike_font = font.Font(self.deprecated_text, self.deprecated_text.cget("font"))
+        strike_font.configure(overstrike=True)
+        self.deprecated_text.tag_configure("deprecated", foreground="#777777", font=strike_font)
+        self._render_deprecated_services()
+        self.deprecated_text.configure(state="disabled")
+
         self.output = tk.Text(container, wrap="word", height=18)
         self.output.pack(fill="both", expand=True, pady=(10, 0))
+        self._sync_service_fields()
+
+    def _render_deprecated_services(self):
+        deprecated = deprecated_services(self.services)
+        if not deprecated:
+            self.deprecated_text.insert("end", "No deprecated services.")
+            return
+        self.deprecated_text.insert("end", "Deprecated services disabled: ")
+        for index, service in enumerate(deprecated):
+            if index:
+                self.deprecated_text.insert("end", ", ")
+            self.deprecated_text.insert("end", service.name, "deprecated")
+
+    def _current_service(self):
+        return self.service_lookup[self.service_var.get()]
+
+    def _sync_service_fields(self):
+        service = self._current_service()
+        actions = actions_for_service(service)
+        self.action_combo.configure(values=actions)
+        if self.action_var.get() not in actions:
+            self.action_var.set(actions[0] if actions else "")
+        self._sync_visible_fields()
+
+    def _grid_or_hide(self, widgets, visible):
+        for widget in widgets:
+            if visible:
+                widget.grid()
+            else:
+                widget.grid_remove()
+
+    def _sync_visible_fields(self):
+        service = self._current_service()
+        state = self._state()
+        fields = required_fields_for_state(state, service)
+        self._grid_or_hide([self.path_label, self.path_entry, self.browse_button], "path" in fields)
+        self._grid_or_hide([self.url_label, self.url_entry], "url" in fields)
+        self._grid_or_hide([self.file_id_label, self.file_id_entry], "file_id" in fields)
+        self._grid_or_hide([self.api_key_label, self.api_key_entry, self.api_key_env_label, self.api_key_env_entry], "api_key" in fields)
+        self.hint_var.set(self._hint_text(state, service, fields))
+
+    def _hint_text(self, state, service, fields):
+        if service.deprecated:
+            return f"{service.display_name} is deprecated and disabled."
+        if not fields:
+            return f"{service.display_name}: no extra fields required."
+        labels = {
+            "path": "choose a file",
+            "url": "enter a download URL",
+            "file_id": "enter a file id",
+            "api_key": "enter an API key or API key environment variable",
+        }
+        return f"{service.display_name} {state.action}: " + "; ".join(labels[field] for field in sorted(fields))
 
     def _state(self) -> GuiState:
         return GuiState(
@@ -129,7 +260,8 @@ class FileUploaderGui:
     def _run_action(self):
         state = self._state()
         try:
-            validate_state(state)
+            service = self._current_service()
+            validate_state(state, service)
             if state.action == "upload":
                 result = self.core.upload(state.service, state.path, **build_options(state))
             elif state.action == "download":

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,7 +1,18 @@
 import unittest
 
-from fileuploader.models import ProviderError
-from fileuploader_gui import GuiState, build_options, default_state, validate_state
+from fileuploader.models import ProviderError, ProviderInfo
+from fileuploader_gui import (
+    GuiState,
+    actions_for_service,
+    active_services,
+    build_options,
+    default_service_name,
+    default_state,
+    deprecated_services,
+    required_fields_for_state,
+    service_names,
+    validate_state,
+)
 
 
 class GuiSmokeTests(unittest.TestCase):
@@ -30,6 +41,51 @@ class GuiSmokeTests(unittest.TestCase):
             validate_state(GuiState(action="upload", path=""))
 
         self.assertEqual(error.exception.code, "path_required")
+
+    def test_active_services_excludes_deprecated_services(self):
+        services = [
+            ProviderInfo(name="gofile", display_name="GoFile"),
+            ProviderInfo(name="bayfiles", display_name="BayFiles", deprecated=True),
+        ]
+
+        self.assertEqual(service_names(active_services(services)), ["gofile"])
+        self.assertEqual(service_names(deprecated_services(services)), ["bayfiles"])
+
+    def test_default_service_prefers_gofile(self):
+        services = [
+            ProviderInfo(name="anonfilesnew", display_name="AnonFilesNew"),
+            ProviderInfo(name="gofile", display_name="GoFile"),
+        ]
+
+        self.assertEqual(default_service_name(services), "gofile")
+
+    def test_actions_follow_provider_capabilities(self):
+        service = ProviderInfo(name="anonfilesnew", display_name="AnonFilesNew", supports_download=False, supports_info=True)
+
+        self.assertEqual(actions_for_service(service), ["upload", "info"])
+
+    def test_required_fields_follow_action_and_api_key(self):
+        service = ProviderInfo(name="anonfilesnew", display_name="AnonFilesNew", supports_info=True, requires_api_key=True)
+
+        fields = required_fields_for_state(GuiState(action="info"), service)
+
+        self.assertEqual(fields, {"file_id", "api_key"})
+
+    def test_validate_state_rejects_unsupported_action(self):
+        service = ProviderInfo(name="jsonbin", display_name="JSONBin", supports_download=False)
+
+        with self.assertRaises(ProviderError) as error:
+            validate_state(GuiState(service="jsonbin", action="download", url="https://example.test"), service)
+
+        self.assertEqual(error.exception.code, "unsupported_action")
+
+    def test_validate_state_requires_api_key_for_api_key_services(self):
+        service = ProviderInfo(name="jsonbin", display_name="JSONBin", requires_api_key=True)
+
+        with self.assertRaises(ProviderError) as error:
+            validate_state(GuiState(service="jsonbin", action="upload", path="file.txt"), service)
+
+        self.assertEqual(error.exception.code, "api_key_required")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Makes the GUI ask only for fields required by the selected service/action.
- Filters the active service selector to non-deprecated providers.
- Shows deprecated providers in a disabled informational strip with strikethrough styling.
- Filters available actions by provider capability, for example GoFile gets upload/download and AnonFilesNew gets upload/info.
- Requires API key fields only for services that need API keys.
- Defaults the GUI to GoFile upload so first use only asks for a file.
- Adds tests for active/deprecated filtering, default service choice, action filtering, required fields, and validation.

## Validation

- `python -m unittest discover -s tests`
- `python -m py_compile fileuploader_gui.py tests\test_gui.py`
- Tkinter smoke construction creates and destroys `FileUploaderGui`; initial state is `gofile upload` with hint `GoFile upload: choose a file`.

Closes #26.