### PR TITLE
Add banner and credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ FileUploader provides a shared provider layer plus three user interfaces:
 
 `python -m fileuploader` is kept as an equivalent package entrypoint for the same CLI.
 
+Created by **j0rd1s3rr4n0**: [jordiserrano.me](https://jordiserrano.me) · [github.com/j0rd1s3rr4n0](https://github.com/j0rd1s3rr4n0)
+
 The current provider set includes GoFile, AnonFilesNew, JSONBin, AnonFiles, and BayFiles. Deprecated providers remain available for compatibility, but upstream APIs may be unreliable.
 
 ## Features
@@ -41,6 +43,12 @@ List all providers:
 
 ```shell
 python -m fileuploader_cli services
+```
+
+Hide the terminal banner and credits when scripting:
+
+```shell
+python -m fileuploader_cli --no-banner services
 ```
 
 Use the guided CLI when you do not remember the flags:
@@ -83,11 +91,11 @@ python -m fileuploader_tui
 ## CLI Reference
 
 ```shell
-python -m fileuploader_cli services [--json] [--active-only]
-python -m fileuploader_cli guided
-python -m fileuploader_cli upload PATH --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json] [--plaintext] [--copy] [--verbose]
-python -m fileuploader_cli download --service SERVICE [--url URL] [--server SERVER --file-id FILE_ID --filename NAME] [--json]
-python -m fileuploader_cli info FILE_ID --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json]
+python -m fileuploader_cli [--no-banner] services [--json] [--active-only]
+python -m fileuploader_cli [--no-banner] guided
+python -m fileuploader_cli [--no-banner] upload PATH --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json] [--plaintext] [--copy] [--verbose]
+python -m fileuploader_cli [--no-banner] download --service SERVICE [--url URL] [--server SERVER --file-id FILE_ID --filename NAME] [--json]
+python -m fileuploader_cli [--no-banner] info FILE_ID --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json]
 ```
 
 See [docs/interfaces.md](docs/interfaces.md) for the interface design notes and framework comparison.
@@ -151,6 +159,7 @@ Expected local smoke checks:
 
 ```shell
 python -m fileuploader_cli services --json
+python -m fileuploader_cli --no-banner services
 python -c "from fileuploader_tui import service_table; print(len(service_table().rows))"
 python -c "import fileuploader_gui; print(fileuploader_gui.default_state())"
 ```

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -8,18 +8,27 @@ FileUploader now exposes one shared provider core through three user interfaces:
 
 `python -m fileuploader` remains available as an equivalent package entrypoint for the same CLI.
 
+Credits are shown in the terminal banner and desktop headers:
+
+- j0rd1s3rr4n0
+- jordiserrano.me
+- github.com/j0rd1s3rr4n0
+
 ## CLI
 
 The primary CLI is built with Typer:
 
 ```shell
 python -m fileuploader_cli services
+python -m fileuploader_cli --no-banner services
 python -m fileuploader_cli guided
 python -m fileuploader_cli upload --service gofile path/to/file.txt --json
 python -m fileuploader_cli info --service anonfilesnew FILE_ID --api-key YOUR_API_KEY
 ```
 
 Use `python -m fileuploader_cli guided` for a step-by-step flow that shows providers, asks for an action, and prompts only for the fields needed by that action.
+
+Use `--no-banner` before the command when you want machine-friendly human output without the banner. JSON output never includes the banner.
 
 Typer is used because it provides a modern command surface while building on Click internally. Click is therefore covered as the underlying command framework. The older argparse scripts remain available as legacy provider-specific entrypoints, but new automation should use `python -m fileuploader`.
 

--- a/fileuploader/branding.py
+++ b/fileuploader/branding.py
@@ -1,0 +1,23 @@
+BANNER = r"""
+  ______ _ _      _    _       _                 _
+ |  ____(_) |    | |  | |     | |               | |
+ | |__   _| | ___| |  | |_ __ | | ___   __ _  __| | ___ _ __
+ |  __| | | |/ _ \ |  | | '_ \| |/ _ \ / _` |/ _` |/ _ \ '__|
+ | |    | | |  __/ |__| | |_) | | (_) | (_| | (_| |  __/ |
+ |_|    |_|_|\___|\____/| .__/|_|\___/ \__,_|\__,_|\___|_|
+                        | |
+                        |_|
+"""
+
+CREDIT_NAME = "j0rd1s3rr4n0"
+CREDIT_SITE = "jordiserrano.me"
+CREDIT_GITHUB = "github.com/j0rd1s3rr4n0"
+CREDIT_LINE = f"by {CREDIT_NAME} | {CREDIT_SITE} | {CREDIT_GITHUB}"
+
+
+def banner_text() -> str:
+    return BANNER.strip("\n") + "\n" + CREDIT_LINE
+
+
+def compact_credit() -> str:
+    return CREDIT_LINE

--- a/fileuploader/cli.py
+++ b/fileuploader/cli.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import typer
 
+from .branding import banner_text
 from .clipboard import copy_text
 from .core import FileUploaderCore
 from .formatting import format_output, service_rows
@@ -14,6 +15,24 @@ app = typer.Typer(
     help="Upload files with GoFile, AnonFilesNew, JSONBin, AnonFiles, or BayFiles.",
     no_args_is_help=True,
 )
+
+
+def _banner_enabled(ctx: typer.Context, json_output: bool = False) -> bool:
+    return not json_output and not (ctx.obj or {}).get("no_banner", False)
+
+
+def _print_banner(ctx: typer.Context, json_output: bool = False):
+    if _banner_enabled(ctx, json_output):
+        typer.echo(banner_text())
+        typer.echo()
+
+
+@app.callback()
+def app_options(
+    ctx: typer.Context,
+    no_banner: bool = typer.Option(False, "--no-banner", help="Hide the FileUploader banner and credits."),
+):
+    ctx.obj = {"no_banner": no_banner}
 
 
 def _resolve_api_key(api_key: Optional[str], api_key_env: Optional[str]) -> Optional[str]:
@@ -55,19 +74,22 @@ def build_guided_info(core: FileUploaderCore, service: str, file_id: str, api_ke
 
 @app.command()
 def services(
+    ctx: typer.Context,
     json_output: bool = typer.Option(False, "--json", help="Print JSON output."),
     include_deprecated: bool = typer.Option(True, "--include-deprecated/--active-only", help="Include deprecated providers."),
 ):
     """List available providers."""
+    _print_banner(ctx, json_output)
     result = FileUploaderCore().services(include_deprecated=include_deprecated)
     services_data = [service.to_dict() for service in result]
     typer.echo(format_output(services_data, json_output=True) if json_output else service_rows(services_data))
 
 
 @app.command()
-def guided():
+def guided(ctx: typer.Context):
     """Run a step-by-step upload, download, or info flow."""
     core = FileUploaderCore()
+    _print_banner(ctx, json_output=False)
     services_data = [service.to_dict() for service in core.services(include_deprecated=True)]
     typer.echo("Available providers:")
     typer.echo(service_rows(services_data))
@@ -106,6 +128,7 @@ def guided():
 
 @app.command()
 def upload(
+    ctx: typer.Context,
     path: str = typer.Argument(..., help="File path to upload, for example ./document.pdf."),
     service: str = typer.Option(..., "--service", "-s", help="Provider name. Run `services` to list choices."),
     api_key: Optional[str] = typer.Option(None, "--api-key", help="Provider API key. Prefer --api-key-env for repeat use."),
@@ -116,6 +139,7 @@ def upload(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output."),
 ):
     """Upload a file with a provider."""
+    _print_banner(ctx, json_output)
     try:
         require_value(service, path, "Provide a file path to upload.", "path_required")
         result = FileUploaderCore().upload(
@@ -141,6 +165,7 @@ def upload(
 
 @app.command()
 def download(
+    ctx: typer.Context,
     service: str = typer.Option(..., "--service", "-s", help="Provider name. GoFile supports download metadata."),
     url: Optional[str] = typer.Option(None, "--url", help="Direct download URL."),
     server: Optional[str] = typer.Option(None, "--server", help="Provider server."),
@@ -150,6 +175,7 @@ def download(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output."),
 ):
     """Download or fetch download metadata."""
+    _print_banner(ctx, json_output)
     try:
         if not url and not all([server, file_id, filename]):
             raise ProviderError(service, "Provide --url or --server, --file-id, and --filename.", code="download_target_required")
@@ -169,6 +195,7 @@ def download(
 
 @app.command()
 def info(
+    ctx: typer.Context,
     file_id: str = typer.Argument(..., help="Provider file id."),
     service: str = typer.Option(..., "--service", "-s", help="Provider name. AnonFilesNew supports info."),
     api_key: Optional[str] = typer.Option(None, "--api-key", help="Provider API key."),
@@ -176,6 +203,7 @@ def info(
     json_output: bool = typer.Option(False, "--json", help="Print JSON output."),
 ):
     """Fetch provider file metadata."""
+    _print_banner(ctx, json_output)
     try:
         require_value(service, file_id, "Provide the provider file id.", "file_id_required")
         result = FileUploaderCore().info(

--- a/fileuploader_gui.py
+++ b/fileuploader_gui.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from tkinter import filedialog, font, messagebox, ttk
 
 from fileuploader import FileUploaderCore
+from fileuploader.branding import compact_credit
 from fileuploader.formatting import format_output
 from fileuploader.models import ProviderError
 
@@ -100,18 +101,48 @@ class FileUploaderGui:
         self.core = core or FileUploaderCore()
         self.root.title("FileUploader")
         self.root.geometry("920x680")
+        self.root.configure(bg="#f6f8fb")
         self.services = self.core.services(include_deprecated=True)
         self.active_service_names = service_names(active_services(self.services))
         self.service_lookup = {service.name: service for service in self.services}
+        self._configure_style()
         self._build_widgets()
 
+    def _configure_style(self):
+        self.style = ttk.Style(self.root)
+        try:
+            self.style.theme_use("clam")
+        except tk.TclError:
+            pass
+        self.style.configure("TFrame", background="#f6f8fb")
+        self.style.configure("TLabel", background="#f6f8fb", foreground="#1f2937", font=("Segoe UI", 10))
+        self.style.configure("Hint.TLabel", background="#f6f8fb", foreground="#4b5563", font=("Segoe UI", 9))
+        self.style.configure("TButton", font=("Segoe UI", 10), padding=6)
+        self.style.configure("Accent.TButton", background="#2563eb", foreground="#ffffff", font=("Segoe UI", 10, "bold"), padding=6)
+        self.style.map("Accent.TButton", background=[("active", "#1d4ed8")], foreground=[("active", "#ffffff")])
+        self.style.configure("TCombobox", padding=4)
+        self.style.configure("TEntry", padding=4)
+
     def _build_widgets(self):
-        container = ttk.Frame(self.root, padding=12)
+        container = ttk.Frame(self.root, padding=14)
         container.pack(fill="both", expand=True)
+
+        header = tk.Frame(container, background="#111827", padx=18, pady=14)
+        header.pack(fill="x", pady=(0, 12))
+        tk.Label(header, text="FileUploader", background="#111827", foreground="#ffffff", font=("Segoe UI", 24, "bold")).pack(anchor="w")
+        tk.Label(
+            header,
+            text="Provider-aware uploads with CLI, GUI, and TUI workflows",
+            background="#111827",
+            foreground="#bfdbfe",
+            font=("Segoe UI", 10),
+        ).pack(anchor="w")
+        tk.Label(header, text=compact_credit(), background="#111827", foreground="#93c5fd", font=("Segoe UI", 9)).pack(anchor="w", pady=(3, 0))
 
         ttk.Label(
             container,
             text="Choose a provider, action, and the required fields. Results appear below and can be copied.",
+            style="Hint.TLabel",
         ).pack(fill="x", pady=(0, 10))
 
         controls = ttk.Frame(container)
@@ -163,24 +194,26 @@ class FileUploaderGui:
 
         self.json_var = tk.BooleanVar(value=False)
         ttk.Checkbutton(controls, text="JSON output", variable=self.json_var).grid(row=5, column=1, sticky="w", padx=6)
-        ttk.Button(controls, text="Run action", command=self._run_action).grid(row=5, column=2, sticky="ew", padx=6, pady=8)
+        ttk.Button(controls, text="Run action", command=self._run_action, style="Accent.TButton").grid(row=5, column=2, sticky="ew", padx=6, pady=8)
         ttk.Button(controls, text="Copy result", command=self._copy_result).grid(row=5, column=3, sticky="ew", padx=6, pady=8)
 
         self.hint_var = tk.StringVar(value="Upload: choose a file. Download: enter URL. Info: enter file id.")
-        ttk.Label(controls, textvariable=self.hint_var).grid(row=6, column=0, columnspan=4, sticky="w", pady=(2, 0))
+        ttk.Label(controls, textvariable=self.hint_var, style="Hint.TLabel").grid(row=6, column=0, columnspan=4, sticky="w", pady=(2, 0))
 
         controls.columnconfigure(1, weight=1)
         controls.columnconfigure(3, weight=1)
 
         self.deprecated_text = tk.Text(container, height=3, wrap="none", borderwidth=0)
         self.deprecated_text.pack(fill="x", pady=(10, 0))
+        self.deprecated_text.configure(background="#f6f8fb", foreground="#6b7280", font=("Segoe UI", 9))
         strike_font = font.Font(self.deprecated_text, self.deprecated_text.cget("font"))
         strike_font.configure(overstrike=True)
         self.deprecated_text.tag_configure("deprecated", foreground="#777777", font=strike_font)
         self._render_deprecated_services()
         self.deprecated_text.configure(state="disabled")
 
-        self.output = tk.Text(container, wrap="word", height=18)
+        self.output = tk.Text(container, wrap="word", height=18, borderwidth=1, relief="solid")
+        self.output.configure(background="#ffffff", foreground="#111827", insertbackground="#111827", font=("Consolas", 10))
         self.output.pack(fill="both", expand=True, pady=(10, 0))
         self._sync_service_fields()
 

--- a/fileuploader_tui.py
+++ b/fileuploader_tui.py
@@ -6,6 +6,7 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from fileuploader import FileUploaderCore
+from fileuploader.branding import banner_text
 from fileuploader.formatting import format_output
 from fileuploader.models import ProviderError
 
@@ -83,7 +84,8 @@ class FileUploaderTui:
             return {"ok": False, "error": exc.to_dict()}
 
     def interactive(self):
-        self.console.print(Panel.fit("FileUploader TUI\nPick a provider, choose an action, then fill only the fields requested."))
+        self.console.print(Panel.fit(banner_text(), title="FileUploader TUI"))
+        self.console.print("Pick a provider, choose an action, then fill only the fields requested.")
         self.console.print(service_table(self.core))
         services = [service.name for service in self.core.services(include_deprecated=True)]
         while True:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
+from fileuploader.branding import CREDIT_GITHUB, CREDIT_NAME, CREDIT_SITE
 from fileuploader.cli import app, build_guided_download, build_guided_info, build_guided_upload
 from fileuploader.models import ProviderError, ProviderInfo, UploadResult
 
@@ -46,9 +47,27 @@ class CliTests(unittest.TestCase):
         result = self.runner.invoke(app, ["services"])
 
         self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn(CREDIT_NAME, result.output)
         self.assertIn("Service", result.output)
         self.assertIn("gofile", result.output)
         self.assertIn("deprecated", result.output)
+
+    @patch("fileuploader.cli.FileUploaderCore", return_value=FakeCore())
+    def test_no_banner_hides_credits(self, _core):
+        result = self.runner.invoke(app, ["--no-banner", "services"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn(CREDIT_NAME, result.output)
+        self.assertNotIn(CREDIT_SITE, result.output)
+        self.assertNotIn(CREDIT_GITHUB, result.output)
+
+    @patch("fileuploader.cli.FileUploaderCore", return_value=FakeCore())
+    def test_json_output_never_includes_banner(self, _core):
+        result = self.runner.invoke(app, ["services", "--json"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn(CREDIT_NAME, result.output)
+        json.loads(result.output)
 
     @patch("fileuploader.cli.FileUploaderCore", return_value=FakeCore())
     def test_upload_outputs_json(self, _core):


### PR DESCRIPTION
## Summary

- Adds shared branding with a FileUploader ASCII banner and credits for `j0rd1s3rr4n0`, `jordiserrano.me`, and `github.com/j0rd1s3rr4n0`.
- Shows the banner in CLI human output by default.
- Adds global `--no-banner` to hide banner and credits for scripting.
- Keeps JSON output banner-free.
- Adds branded GUI header with credits and a more polished Tkinter style.
- Adds branded TUI header.
- Updates README and interface docs.
- Adds tests for banner visibility, `--no-banner`, and JSON output cleanliness.

## Validation

- `python -m unittest discover -s tests`
- `python -m py_compile fileuploader\__init__.py fileuploader\__main__.py fileuploader\branding.py fileuploader\cli.py fileuploader\clipboard.py fileuploader\core.py fileuploader\formatting.py fileuploader\models.py fileuploader\providers.py fileuploader\registry.py fileuploader\validation.py fileuploader_cli.py fileuploader_gui.py fileuploader_tui.py`
- `python -m fileuploader_cli services`
- `python -m fileuploader_cli --no-banner services`
- `python -m fileuploader_cli services --json`
- Tkinter smoke construction starts in `gofile upload`.

Closes #28.