### PR TITLE
Add no-registration upload providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ FileUploader provides a shared provider layer plus three user interfaces:
 
 `python -m fileuploader` is kept as an equivalent package entrypoint for the same CLI.
 
-Created by **j0rd1s3rr4n0**: [jordiserrano.me](https://jordiserrano.me) · [github.com/j0rd1s3rr4n0](https://github.com/j0rd1s3rr4n0)
+Created by **j0rd1s3rr4n0**: [jordiserrano.me](https://jordiserrano.me) | [github.com/j0rd1s3rr4n0](https://github.com/j0rd1s3rr4n0)
 
-The current provider set includes GoFile, AnonFilesNew, JSONBin, AnonFiles, and BayFiles. Deprecated providers remain available for compatibility, but upstream APIs may be unreliable.
+The current provider set includes GoFile plus a broad no-registration upload set: 0x0.st, MoonPush, Temp.sh, tmpfile.link, blipbin, EasySend, dropfile.dev, cupload.io, and qurl.sh. Deprecated providers remain available for compatibility, but upstream APIs may be unreliable.
 
 ## Features
 
@@ -63,6 +63,14 @@ Upload a file with GoFile and print JSON:
 python -m fileuploader_cli upload --service gofile path/to/file.txt --json
 ```
 
+Upload without registration:
+
+```shell
+python -m fileuploader_cli upload --service moonpush path/to/file.txt
+python -m fileuploader_cli upload --service 0x0 path/to/file.txt
+python -m fileuploader_cli upload --service tmpfilelink path/to/file.txt
+```
+
 Upload with AnonFilesNew using an API key:
 
 ```shell
@@ -105,12 +113,34 @@ See [docs/interfaces.md](docs/interfaces.md) for the interface design notes and 
 | Provider | Service name | Upload | Download | Info | API key | Status |
 | --- | --- | --- | --- | --- | --- | --- |
 | GoFile | `gofile` | Yes | Yes | No | No | Active |
+| 0x0.st | `0x0` | Yes | No | No | No | Active |
+| MoonPush | `moonpush` | Yes | No | Yes | No | Active |
+| Temp.sh | `tempsh` | Yes | No | No | No | Active |
+| tmpfile.link | `tmpfilelink` | Yes | No | No | No | Active |
+| blipbin | `blipbin` | Yes | No | No | No | Active |
+| EasySend | `easysend` | Yes | No | No | No | Active |
+| dropfile.dev | `dropfiledev` | Yes | No | No | No | Active |
+| cupload.io | `cupload` | Yes | No | No | No | Active |
+| qurl.sh | `qurl` | Yes | No | No | No | Active |
 | AnonFilesNew | `anonfilesnew` | Yes | No | Yes | Yes | Active |
 | JSONBin | `jsonbin` | Yes | No | No | Yes | Active |
 | AnonFiles | `anonfiles` | Yes | No | No | No | Deprecated |
 | BayFiles | `bayfiles` | Yes | No | No | No | Deprecated |
 
 ## Provider-Specific Notes
+
+### No-registration providers
+
+Use these when you want a quick public link without creating an account or passing API keys:
+
+```shell
+python -m fileuploader_cli upload --service moonpush path/to/file.txt
+python -m fileuploader_cli upload --service tempsh path/to/file.txt
+python -m fileuploader_cli upload --service blipbin path/to/file.txt
+python -m fileuploader_cli upload --service dropfiledev path/to/file.txt
+```
+
+The no-registration providers are best for temporary sharing and automation. Retention, size limits, and rate limits are controlled by each upstream service.
 
 ### GoFile
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -23,12 +23,16 @@ python -m fileuploader_cli services
 python -m fileuploader_cli --no-banner services
 python -m fileuploader_cli guided
 python -m fileuploader_cli upload --service gofile path/to/file.txt --json
+python -m fileuploader_cli upload --service moonpush path/to/file.txt
+python -m fileuploader_cli upload --service tmpfilelink path/to/file.txt
 python -m fileuploader_cli info --service anonfilesnew FILE_ID --api-key YOUR_API_KEY
 ```
 
 Use `python -m fileuploader_cli guided` for a step-by-step flow that shows providers, asks for an action, and prompts only for the fields needed by that action.
 
 Use `--no-banner` before the command when you want machine-friendly human output without the banner. JSON output never includes the banner.
+
+For quick temporary sharing, prefer the no-registration providers such as `moonpush`, `0x0`, `tempsh`, `tmpfilelink`, `blipbin`, `easysend`, `dropfiledev`, `cupload`, and `qurl`.
 
 Typer is used because it provides a modern command surface while building on Click internally. Click is therefore covered as the underlying command framework. The older argparse scripts remain available as legacy provider-specific entrypoints, but new automation should use `python -m fileuploader`.
 

--- a/fileuploader/providers.py
+++ b/fileuploader/providers.py
@@ -31,14 +31,32 @@ class BaseProvider:
             raise ProviderError(self.info.name, f"File not found: {filepath}", code="file_not_found")
         return path
 
-    def _post_file(self, url, filepath, **kwargs):
+    def _post_file(self, url, filepath, file_field="file", **kwargs):
         path = self._ensure_file(filepath)
         try:
             with path.open("rb") as file_handle:
-                response = self.http.post(url, files={"file": (path.name, file_handle)}, **kwargs)
+                response = self.http.post(url, files={file_field: (path.name, file_handle)}, **kwargs)
         except requests.RequestException as exc:
             raise ProviderError(self.info.name, str(exc), code="network_error") from exc
         return self._json_response(response)
+
+    def _post_file_text(self, url, filepath, file_field="file", **kwargs):
+        path = self._ensure_file(filepath)
+        try:
+            with path.open("rb") as file_handle:
+                response = self.http.post(url, files={file_field: (path.name, file_handle)}, **kwargs)
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._text_response(response)
+
+    def _put_file_text(self, url, filepath, **kwargs):
+        path = self._ensure_file(filepath)
+        try:
+            with path.open("rb") as file_handle:
+                response = self.http.put(url, data=file_handle, **kwargs)
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._text_response(response)
 
     def _json_response(self, response):
         try:
@@ -49,6 +67,14 @@ class BaseProvider:
             message = payload.get("message") or payload.get("error", {}).get("message") or response.text
             raise ProviderError(self.info.name, message, code="http_error")
         return payload
+
+    def _text_response(self, response):
+        text = getattr(response, "text", "").strip()
+        if getattr(response, "status_code", 200) >= 400:
+            raise ProviderError(self.info.name, text or "Provider returned an HTTP error", code="http_error")
+        if not text:
+            raise ProviderError(self.info.name, "Provider returned an empty response", code="empty_response")
+        return text
 
 
 class GoFileProvider(BaseProvider):
@@ -174,6 +200,171 @@ class JsonBinProvider(BaseProvider):
             metadata=metadata,
             raw=payload,
         )
+
+
+class ZeroXZeroProvider(BaseProvider):
+    info = ProviderInfo(
+        name="0x0",
+        display_name="0x0.st",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        url = self._post_file_text("https://0x0.st", filepath)
+        return UploadResult(provider=self.info.name, status=True, url=url, raw={"response": url})
+
+
+class MoonPushProvider(BaseProvider):
+    info = ProviderInfo(
+        name="moonpush",
+        display_name="MoonPush",
+        supports_info=True,
+    )
+
+    def upload(self, filepath, **options):
+        payload = self._post_file("https://www.moonpush.com/api/upload", filepath)
+        url = payload.get("shareUrl") or payload.get("share_url") or payload.get("url")
+        download_url = payload.get("downloadUrl") or payload.get("download_url")
+        file_id = payload.get("id") or payload.get("pipeId") or payload.get("fileId")
+        if not url and not download_url:
+            raise ProviderError(self.info.name, "Upload response did not include a URL", code="missing_url")
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=url or download_url,
+            short_url=download_url if url and download_url != url else None,
+            file_id=file_id,
+            metadata=payload,
+            raw=payload,
+        )
+
+    def info_file(self, file_id, **options):
+        try:
+            response = self.http.get(f"https://www.moonpush.com/api/share/{file_id}")
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._json_response(response)
+
+
+class TempShProvider(BaseProvider):
+    info = ProviderInfo(
+        name="tempsh",
+        display_name="Temp.sh",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        url = self._post_file_text("https://temp.sh/upload", filepath)
+        return UploadResult(provider=self.info.name, status=True, url=url, raw={"response": url})
+
+
+class TmpFileLinkProvider(BaseProvider):
+    info = ProviderInfo(
+        name="tmpfilelink",
+        display_name="tmpfile.link",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        payload = self._post_file("https://tmpfile.link/api/upload", filepath)
+        url = payload.get("downloadLink") or payload.get("download_link") or payload.get("url")
+        if not url:
+            raise ProviderError(self.info.name, "Upload response did not include a download link", code="missing_url")
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=url,
+            short_url=payload.get("downloadLinkEncoded"),
+            file_id=payload.get("fileId") or payload.get("id"),
+            metadata=payload,
+            raw=payload,
+        )
+
+
+class BlipbinProvider(BaseProvider):
+    info = ProviderInfo(
+        name="blipbin",
+        display_name="blipbin",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        path = self._ensure_file(filepath)
+        try:
+            with path.open("rb") as file_handle:
+                response = self.http.post("https://blipbin.com/upload", files={"file": (path.name, file_handle)})
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        url = self._text_response(response)
+        token = getattr(response, "headers", {}).get("X-Token")
+        metadata = {"delete_token": token} if token else {}
+        return UploadResult(provider=self.info.name, status=True, url=url, metadata=metadata, raw={"response": url})
+
+
+class EasySendProvider(BaseProvider):
+    info = ProviderInfo(
+        name="easysend",
+        display_name="EasySend",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        payload = self._post_file("https://easysend.co/api/v1/upload", filepath, file_field="files[]")
+        url = payload.get("share_url") or payload.get("shareUrl")
+        short_code = payload.get("short_code") or payload.get("shortCode")
+        if not url and short_code:
+            url = f"https://easysend.co/{short_code}"
+        elif url and url.startswith("/"):
+            url = f"https://easysend.co{url}"
+        if not url:
+            raise ProviderError(self.info.name, "Upload response did not include a share URL", code="missing_url")
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=url,
+            file_id=short_code,
+            metadata=payload,
+            raw=payload,
+        )
+
+
+class DropFileDevProvider(BaseProvider):
+    info = ProviderInfo(
+        name="dropfiledev",
+        display_name="dropfile.dev",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        path = self._ensure_file(filepath)
+        url = self._put_file_text(f"https://dropfile.dev/{path.name}", path)
+        return UploadResult(provider=self.info.name, status=True, url=url, raw={"response": url})
+
+
+class CuploadProvider(BaseProvider):
+    info = ProviderInfo(
+        name="cupload",
+        display_name="cupload.io",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        path = self._ensure_file(filepath)
+        url = self._put_file_text(f"https://cupload.io/{path.name}", path)
+        return UploadResult(provider=self.info.name, status=True, url=url, raw={"response": url})
+
+
+class QurlProvider(BaseProvider):
+    info = ProviderInfo(
+        name="qurl",
+        display_name="qurl.sh",
+        supports_info=False,
+    )
+
+    def upload(self, filepath, **options):
+        path = self._ensure_file(filepath)
+        url = self._put_file_text(f"https://qurl.sh/{path.name}", path)
+        return UploadResult(provider=self.info.name, status=True, url=url, raw={"response": url})
 
 
 class AnonFilesProvider(AnonFilesNewProvider):

--- a/fileuploader/registry.py
+++ b/fileuploader/registry.py
@@ -3,8 +3,17 @@ from .providers import (
     AnonFilesNewProvider,
     AnonFilesProvider,
     BayFilesProvider,
+    BlipbinProvider,
+    CuploadProvider,
+    DropFileDevProvider,
+    EasySendProvider,
     GoFileProvider,
     JsonBinProvider,
+    MoonPushProvider,
+    QurlProvider,
+    TempShProvider,
+    TmpFileLinkProvider,
+    ZeroXZeroProvider,
 )
 
 
@@ -35,6 +44,15 @@ def create_default_registry():
             GoFileProvider(),
             AnonFilesNewProvider(),
             JsonBinProvider(),
+            ZeroXZeroProvider(),
+            MoonPushProvider(),
+            TempShProvider(),
+            TmpFileLinkProvider(),
+            BlipbinProvider(),
+            EasySendProvider(),
+            DropFileDevProvider(),
+            CuploadProvider(),
+            QurlProvider(),
             AnonFilesProvider(),
             BayFilesProvider(),
         ]

--- a/tests/test_provider_core.py
+++ b/tests/test_provider_core.py
@@ -4,31 +4,52 @@ import unittest
 from pathlib import Path
 
 from fileuploader import FileUploaderCore, ProviderError, create_default_registry
-from fileuploader.providers import AnonFilesNewProvider, GoFileProvider
+from fileuploader.providers import (
+    AnonFilesNewProvider,
+    BlipbinProvider,
+    CuploadProvider,
+    DropFileDevProvider,
+    EasySendProvider,
+    GoFileProvider,
+    MoonPushProvider,
+    QurlProvider,
+    TempShProvider,
+    TmpFileLinkProvider,
+    ZeroXZeroProvider,
+)
 
 
 class FakeResponse:
-    def __init__(self, payload, status_code=200):
+    def __init__(self, payload, status_code=200, text=None, headers=None):
         self.payload = payload
         self.status_code = status_code
-        self.text = json.dumps(payload)
+        self.text = text if text is not None else json.dumps(payload)
+        self.headers = headers or {}
 
     def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
         return self.payload
 
 
 class FakeHttp:
-    def __init__(self, payload):
+    def __init__(self, payload=None, text=None, headers=None):
         self.payload = payload
+        self.text = text
+        self.headers = headers
         self.calls = []
 
     def post(self, url, **kwargs):
         self.calls.append(("post", url, kwargs))
-        return FakeResponse(self.payload)
+        return FakeResponse(self.payload, text=self.text, headers=self.headers)
+
+    def put(self, url, **kwargs):
+        self.calls.append(("put", url, kwargs))
+        return FakeResponse(self.payload, text=self.text, headers=self.headers)
 
     def get(self, url, **kwargs):
         self.calls.append(("get", url, kwargs))
-        return FakeResponse(self.payload)
+        return FakeResponse(self.payload, text=self.text, headers=self.headers)
 
 
 class ProviderCoreTests(unittest.TestCase):
@@ -36,7 +57,25 @@ class ProviderCoreTests(unittest.TestCase):
         services = FileUploaderCore(create_default_registry()).services()
         names = {service.name for service in services}
 
-        self.assertEqual({"anonfiles", "anonfilesnew", "bayfiles", "gofile", "jsonbin"}, names)
+        self.assertEqual(
+            {
+                "0x0",
+                "anonfiles",
+                "anonfilesnew",
+                "bayfiles",
+                "blipbin",
+                "cupload",
+                "dropfiledev",
+                "easysend",
+                "gofile",
+                "jsonbin",
+                "moonpush",
+                "qurl",
+                "tempsh",
+                "tmpfilelink",
+            },
+            names,
+        )
         self.assertTrue(any(service.deprecated for service in services if service.name == "anonfiles"))
         self.assertTrue(any(service.deprecated for service in services if service.name == "bayfiles"))
 
@@ -95,6 +134,99 @@ class ProviderCoreTests(unittest.TestCase):
         self.assertEqual(result.file_id, "file-1")
         self.assertEqual(result.short_url, "https://anonfilesnew.com/s")
         self.assertIn("?key=secret", http.calls[0][1])
+
+    def test_plain_text_multipart_providers_normalize_urls(self):
+        providers = [
+            (ZeroXZeroProvider, "https://0x0.st/abc.txt"),
+            (TempShProvider, "https://temp.sh/abc/sample.txt"),
+        ]
+
+        for provider_class, expected_url in providers:
+            with self.subTest(provider=provider_class.__name__):
+                provider = provider_class(http_client=FakeHttp(text=f"{expected_url}\n"))
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    source = Path(temp_dir) / "sample.txt"
+                    source.write_text("data", encoding="utf-8")
+                    result = provider.upload(source)
+
+                self.assertEqual(result.url, expected_url)
+                self.assertTrue(result.status)
+
+    def test_moonpush_upload_normalizes_json_urls(self):
+        payload = {
+            "shareUrl": "https://www.moonpush.com/share/abc#key",
+            "downloadUrl": "https://www.moonpush.com/api/dl/abc",
+            "pipeId": "abc",
+        }
+        provider = MoonPushProvider(http_client=FakeHttp(payload))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source)
+
+        self.assertEqual(result.url, "https://www.moonpush.com/share/abc#key")
+        self.assertEqual(result.short_url, "https://www.moonpush.com/api/dl/abc")
+        self.assertEqual(result.file_id, "abc")
+
+    def test_tmpfilelink_upload_normalizes_download_link(self):
+        payload = {
+            "fileName": "sample.txt",
+            "downloadLink": "https://d.tmpfile.link/sample.txt",
+            "downloadLinkEncoded": "https://tmpfile.link/qr/sample",
+        }
+        provider = TmpFileLinkProvider(http_client=FakeHttp(payload))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source)
+
+        self.assertEqual(result.url, "https://d.tmpfile.link/sample.txt")
+        self.assertEqual(result.short_url, "https://tmpfile.link/qr/sample")
+
+    def test_blipbin_upload_preserves_delete_token(self):
+        provider = BlipbinProvider(http_client=FakeHttp(text="https://blipbin.com/a3Bx9k", headers={"X-Token": "delete-me"}))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source)
+
+        self.assertEqual(result.url, "https://blipbin.com/a3Bx9k")
+        self.assertEqual(result.metadata["delete_token"], "delete-me")
+
+    def test_easysend_upload_expands_relative_share_url(self):
+        provider = EasySendProvider(http_client=FakeHttp({"share_url": "/Ab3Kz", "short_code": "Ab3Kz"}))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source)
+
+        self.assertEqual(result.url, "https://easysend.co/Ab3Kz")
+        self.assertEqual(result.file_id, "Ab3Kz")
+
+    def test_put_upload_providers_normalize_urls(self):
+        providers = [
+            (DropFileDevProvider, "dropfiledev", "https://dropfile.dev/f/sample.txt"),
+            (CuploadProvider, "cupload", "https://cupload.io/f/sample.txt"),
+            (QurlProvider, "qurl", "https://qurl.sh/f/sample.txt"),
+        ]
+
+        for provider_class, provider_name, expected_url in providers:
+            with self.subTest(provider=provider_name):
+                http = FakeHttp(text=expected_url)
+                provider = provider_class(http_client=http)
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    source = Path(temp_dir) / "sample.txt"
+                    source.write_text("data", encoding="utf-8")
+                    result = provider.upload(source)
+
+                self.assertEqual(result.provider, provider_name)
+                self.assertEqual(result.url, expected_url)
+                self.assertEqual(http.calls[0][0], "put")
+                self.assertTrue(http.calls[0][1].endswith("/sample.txt"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds no-registration providers: 0x0.st, MoonPush, Temp.sh, tmpfile.link, blipbin, EasySend, dropfile.dev, cupload.io, and qurl.sh.
- Adds shared helpers for plain-text upload responses and PUT-style uploads.
- Updates README and interface docs with no-registration examples and provider matrix entries.

## Validation
- `python -m unittest discover -s tests`
- `python -m py_compile` on package modules and launchers
- `python -m fileuploader_cli services --json`
- `python -m fileuploader_cli --no-banner services`
- `python -m fileuploader_cli --no-banner services --active-only`

Closes #30.