### PR TITLE
Modernize GUI and TUI presentation

### DIFF
--- a/fileuploader_gui.py
+++ b/fileuploader_gui.py
@@ -8,6 +8,23 @@ from fileuploader.formatting import format_output
 from fileuploader.models import ProviderError
 
 
+PALETTE = {
+    "bg": "#eef2f7",
+    "surface": "#ffffff",
+    "surface_alt": "#f8fafc",
+    "ink": "#111827",
+    "muted": "#64748b",
+    "line": "#d9e2ef",
+    "brand": "#0f766e",
+    "brand_hover": "#115e59",
+    "brand_soft": "#ccfbf1",
+    "danger": "#b91c1c",
+    "warning": "#b45309",
+    "success": "#047857",
+    "disabled": "#6b7280",
+}
+
+
 @dataclass
 class GuiState:
     service: str = "gofile"
@@ -69,6 +86,26 @@ def actions_for_service(service):
     return actions
 
 
+def provider_status(service) -> str:
+    if not service.active:
+        return "disabled"
+    if service.deprecated:
+        return "deprecated"
+    return "active"
+
+
+def provider_summary(service) -> str:
+    capabilities = []
+    if service.supports_upload:
+        capabilities.append("upload")
+    if service.supports_download:
+        capabilities.append("download")
+    if service.supports_info:
+        capabilities.append("info")
+    credential = "token required" if service.requires_api_key else "no account needed"
+    return f"{service.display_name} | {', '.join(capabilities) or 'listed only'} | {credential}"
+
+
 def required_fields_for_state(state: GuiState, service) -> set[str]:
     fields = set()
     if state.action == "upload":
@@ -100,8 +137,9 @@ class FileUploaderGui:
         self.root = root
         self.core = core or FileUploaderCore()
         self.root.title("FileUploader")
-        self.root.geometry("920x680")
-        self.root.configure(bg="#f6f8fb")
+        self.root.geometry("1080x760")
+        self.root.minsize(920, 640)
+        self.root.configure(bg=PALETTE["bg"])
         self.services = self.core.services(include_deprecated=True)
         self.active_service_names = service_names(active_services(self.services))
         self.service_lookup = {service.name: service for service in self.services}
@@ -114,107 +152,146 @@ class FileUploaderGui:
             self.style.theme_use("clam")
         except tk.TclError:
             pass
-        self.style.configure("TFrame", background="#f6f8fb")
-        self.style.configure("TLabel", background="#f6f8fb", foreground="#1f2937", font=("Segoe UI", 10))
-        self.style.configure("Hint.TLabel", background="#f6f8fb", foreground="#4b5563", font=("Segoe UI", 9))
-        self.style.configure("TButton", font=("Segoe UI", 10), padding=6)
-        self.style.configure("Accent.TButton", background="#2563eb", foreground="#ffffff", font=("Segoe UI", 10, "bold"), padding=6)
-        self.style.map("Accent.TButton", background=[("active", "#1d4ed8")], foreground=[("active", "#ffffff")])
-        self.style.configure("TCombobox", padding=4)
-        self.style.configure("TEntry", padding=4)
+        self.style.configure("TFrame", background=PALETTE["bg"])
+        self.style.configure("Surface.TFrame", background=PALETTE["surface"])
+        self.style.configure("TLabel", background=PALETTE["surface"], foreground=PALETTE["ink"], font=("Segoe UI", 10))
+        self.style.configure("Page.TLabel", background=PALETTE["bg"], foreground=PALETTE["ink"], font=("Segoe UI", 10))
+        self.style.configure("Heading.TLabel", background=PALETTE["surface"], foreground=PALETTE["ink"], font=("Segoe UI Semibold", 13))
+        self.style.configure("Hint.TLabel", background=PALETTE["surface"], foreground=PALETTE["muted"], font=("Segoe UI", 9))
+        self.style.configure("Status.TLabel", background=PALETTE["brand_soft"], foreground=PALETTE["brand"], font=("Segoe UI Semibold", 9), padding=(8, 4))
+        self.style.configure("TButton", font=("Segoe UI", 10), padding=(10, 7))
+        self.style.configure("Accent.TButton", background=PALETTE["brand"], foreground="#ffffff", font=("Segoe UI Semibold", 10), padding=(12, 8))
+        self.style.map("Accent.TButton", background=[("active", PALETTE["brand_hover"])], foreground=[("active", "#ffffff")])
+        self.style.configure("TCombobox", padding=6, fieldbackground=PALETTE["surface_alt"], background=PALETTE["surface_alt"])
+        self.style.configure("TEntry", padding=7, fieldbackground=PALETTE["surface_alt"])
+        self.style.configure("TCheckbutton", background=PALETTE["surface"], foreground=PALETTE["ink"], font=("Segoe UI", 10))
 
     def _build_widgets(self):
-        container = ttk.Frame(self.root, padding=14)
+        container = ttk.Frame(self.root, padding=18)
         container.pack(fill="both", expand=True)
 
-        header = tk.Frame(container, background="#111827", padx=18, pady=14)
-        header.pack(fill="x", pady=(0, 12))
-        tk.Label(header, text="FileUploader", background="#111827", foreground="#ffffff", font=("Segoe UI", 24, "bold")).pack(anchor="w")
+        header = tk.Frame(container, background=PALETTE["ink"], padx=20, pady=16, highlightthickness=0)
+        header.pack(fill="x", pady=(0, 14))
+        title_row = tk.Frame(header, background=PALETTE["ink"])
+        title_row.pack(fill="x")
+        mark = tk.Canvas(title_row, width=38, height=38, bg=PALETTE["ink"], highlightthickness=0)
+        mark.pack(side="left", padx=(0, 12))
+        mark.create_oval(3, 3, 35, 35, fill=PALETTE["brand"], outline="")
+        mark.create_line(19, 10, 19, 25, fill="#ffffff", width=3)
+        mark.create_line(12, 17, 19, 10, 26, 17, fill="#ffffff", width=3)
+        mark.create_rectangle(11, 25, 27, 29, fill="#ffffff", outline="")
+        title_stack = tk.Frame(title_row, background=PALETTE["ink"])
+        title_stack.pack(side="left", fill="x", expand=True)
+        tk.Label(title_stack, text="FileUploader", background=PALETTE["ink"], foreground="#ffffff", font=("Segoe UI Semibold", 24)).pack(anchor="w")
         tk.Label(
-            header,
-            text="Provider-aware uploads with CLI, GUI, and TUI workflows",
-            background="#111827",
-            foreground="#bfdbfe",
+            title_stack,
+            text="Unified uploads for temporary links, cloud accounts, scripts, and desktop workflows",
+            background=PALETTE["ink"],
+            foreground="#cbd5e1",
             font=("Segoe UI", 10),
-        ).pack(anchor="w")
-        tk.Label(header, text=compact_credit(), background="#111827", foreground="#93c5fd", font=("Segoe UI", 9)).pack(anchor="w", pady=(3, 0))
+        ).pack(anchor="w", pady=(1, 0))
+        tk.Label(header, text=compact_credit(), background=PALETTE["ink"], foreground="#99f6e4", font=("Segoe UI", 9)).pack(anchor="w", pady=(8, 0))
 
-        ttk.Label(
-            container,
-            text="Choose a provider, action, and the required fields. Results appear below and can be copied.",
-            style="Hint.TLabel",
-        ).pack(fill="x", pady=(0, 10))
+        main = ttk.Frame(container)
+        main.pack(fill="both", expand=True)
+        main.columnconfigure(0, weight=0, minsize=380)
+        main.columnconfigure(1, weight=1)
+        main.rowconfigure(0, weight=1)
 
-        controls = ttk.Frame(container)
-        controls.pack(fill="x")
+        controls = tk.Frame(main, background=PALETTE["surface"], padx=18, pady=16, highlightbackground=PALETTE["line"], highlightthickness=1)
+        controls.grid(row=0, column=0, sticky="nsew", padx=(0, 14))
 
-        ttk.Label(controls, text="Active service").grid(row=0, column=0, sticky="w")
+        ttk.Label(controls, text="Upload setup", style="Heading.TLabel").grid(row=0, column=0, columnspan=4, sticky="w", pady=(0, 12))
+
+        ttk.Label(controls, text="Provider").grid(row=1, column=0, sticky="w", pady=(0, 5))
         self.service_var = tk.StringVar(value=default_service_name(self.services))
         self.service_combo = ttk.Combobox(controls, textvariable=self.service_var, values=self.active_service_names, state="readonly")
-        self.service_combo.grid(row=0, column=1, sticky="ew", padx=6)
+        self.service_combo.grid(row=2, column=0, columnspan=4, sticky="ew", pady=(0, 10))
         self.service_combo.bind("<<ComboboxSelected>>", lambda _event: self._sync_service_fields())
 
-        ttk.Label(controls, text="Action").grid(row=0, column=2, sticky="w")
+        self.provider_meta_var = tk.StringVar(value="")
+        self.provider_status_var = tk.StringVar(value="")
+        ttk.Label(controls, textvariable=self.provider_meta_var, style="Hint.TLabel").grid(row=3, column=0, columnspan=3, sticky="w", pady=(0, 8))
+        ttk.Label(controls, textvariable=self.provider_status_var, style="Status.TLabel").grid(row=3, column=3, sticky="e", pady=(0, 8))
+
+        ttk.Label(controls, text="Action").grid(row=4, column=0, sticky="w", pady=(2, 5))
         self.action_var = tk.StringVar(value="upload")
         self.action_combo = ttk.Combobox(controls, textvariable=self.action_var, values=["upload"], state="readonly")
-        self.action_combo.grid(row=0, column=3, sticky="ew", padx=6)
+        self.action_combo.grid(row=5, column=0, columnspan=4, sticky="ew", pady=(0, 10))
         self.action_combo.bind("<<ComboboxSelected>>", lambda _event: self._sync_visible_fields())
 
         self.path_label = ttk.Label(controls, text="File")
-        self.path_label.grid(row=1, column=0, sticky="w", pady=6)
+        self.path_label.grid(row=6, column=0, sticky="w", pady=(2, 5))
         self.path_var = tk.StringVar()
         self.path_entry = ttk.Entry(controls, textvariable=self.path_var)
-        self.path_entry.grid(row=1, column=1, columnspan=2, sticky="ew", padx=6)
+        self.path_entry.grid(row=7, column=0, columnspan=3, sticky="ew", pady=(0, 10))
         self.browse_button = ttk.Button(controls, text="Browse", command=self._browse_file)
-        self.browse_button.grid(row=1, column=3, sticky="ew", padx=6)
+        self.browse_button.grid(row=7, column=3, sticky="ew", padx=(8, 0), pady=(0, 10))
 
         self.url_label = ttk.Label(controls, text="Download URL")
-        self.url_label.grid(row=2, column=0, sticky="w", pady=6)
+        self.url_label.grid(row=8, column=0, sticky="w", pady=(2, 5))
         self.url_var = tk.StringVar()
         self.url_entry = ttk.Entry(controls, textvariable=self.url_var)
-        self.url_entry.grid(row=2, column=1, columnspan=3, sticky="ew", padx=6)
+        self.url_entry.grid(row=9, column=0, columnspan=4, sticky="ew", pady=(0, 10))
 
         self.file_id_label = ttk.Label(controls, text="File ID")
-        self.file_id_label.grid(row=3, column=0, sticky="w", pady=6)
+        self.file_id_label.grid(row=10, column=0, sticky="w", pady=(2, 5))
         self.file_id_var = tk.StringVar()
         self.file_id_entry = ttk.Entry(controls, textvariable=self.file_id_var)
-        self.file_id_entry.grid(row=3, column=1, columnspan=3, sticky="ew", padx=6)
+        self.file_id_entry.grid(row=11, column=0, columnspan=4, sticky="ew", pady=(0, 10))
 
-        self.api_key_label = ttk.Label(controls, text="API Key")
-        self.api_key_label.grid(row=4, column=0, sticky="w", pady=6)
+        self.api_key_label = ttk.Label(controls, text="API key / access token")
+        self.api_key_label.grid(row=12, column=0, sticky="w", pady=(2, 5))
         self.api_key_var = tk.StringVar()
         self.api_key_entry = ttk.Entry(controls, textvariable=self.api_key_var, show="*")
-        self.api_key_entry.grid(row=4, column=1, sticky="ew", padx=6)
+        self.api_key_entry.grid(row=13, column=0, columnspan=4, sticky="ew", pady=(0, 10))
 
-        self.api_key_env_label = ttk.Label(controls, text="API Key Env")
-        self.api_key_env_label.grid(row=4, column=2, sticky="w", pady=6)
+        self.api_key_env_label = ttk.Label(controls, text="Environment variable")
+        self.api_key_env_label.grid(row=14, column=0, sticky="w", pady=(2, 5))
         self.api_key_env_var = tk.StringVar()
         self.api_key_env_entry = ttk.Entry(controls, textvariable=self.api_key_env_var)
-        self.api_key_env_entry.grid(row=4, column=3, sticky="ew", padx=6)
+        self.api_key_env_entry.grid(row=15, column=0, columnspan=4, sticky="ew", pady=(0, 10))
 
         self.json_var = tk.BooleanVar(value=False)
-        ttk.Checkbutton(controls, text="JSON output", variable=self.json_var).grid(row=5, column=1, sticky="w", padx=6)
-        ttk.Button(controls, text="Run action", command=self._run_action, style="Accent.TButton").grid(row=5, column=2, sticky="ew", padx=6, pady=8)
-        ttk.Button(controls, text="Copy result", command=self._copy_result).grid(row=5, column=3, sticky="ew", padx=6, pady=8)
+        ttk.Checkbutton(controls, text="JSON output", variable=self.json_var).grid(row=16, column=0, columnspan=2, sticky="w", pady=(0, 12))
+        ttk.Button(controls, text="Run", command=self._run_action, style="Accent.TButton").grid(row=17, column=0, columnspan=2, sticky="ew", pady=(0, 10), padx=(0, 6))
+        ttk.Button(controls, text="Copy", command=self._copy_result).grid(row=17, column=2, columnspan=2, sticky="ew", pady=(0, 10), padx=(6, 0))
 
         self.hint_var = tk.StringVar(value="Upload: choose a file. Download: enter URL. Info: enter file id.")
-        ttk.Label(controls, textvariable=self.hint_var, style="Hint.TLabel").grid(row=6, column=0, columnspan=4, sticky="w", pady=(2, 0))
+        ttk.Label(controls, textvariable=self.hint_var, style="Hint.TLabel", wraplength=330).grid(row=18, column=0, columnspan=4, sticky="ew", pady=(2, 0))
 
-        controls.columnconfigure(1, weight=1)
-        controls.columnconfigure(3, weight=1)
+        for column in range(4):
+            controls.columnconfigure(column, weight=1)
 
         self.deprecated_text = tk.Text(container, height=3, wrap="none", borderwidth=0)
-        self.deprecated_text.pack(fill="x", pady=(10, 0))
-        self.deprecated_text.configure(background="#f6f8fb", foreground="#6b7280", font=("Segoe UI", 9))
+        self.deprecated_text.pack(fill="x", pady=(12, 0))
+        self.deprecated_text.configure(background=PALETTE["bg"], foreground=PALETTE["muted"], font=("Segoe UI", 9))
         strike_font = font.Font(self.deprecated_text, self.deprecated_text.cget("font"))
         strike_font.configure(overstrike=True)
-        self.deprecated_text.tag_configure("deprecated", foreground="#777777", font=strike_font)
+        self.deprecated_text.tag_configure("deprecated", foreground=PALETTE["disabled"], font=strike_font)
         self._render_deprecated_services()
         self.deprecated_text.configure(state="disabled")
 
-        self.output = tk.Text(container, wrap="word", height=18, borderwidth=1, relief="solid")
-        self.output.configure(background="#ffffff", foreground="#111827", insertbackground="#111827", font=("Consolas", 10))
-        self.output.pack(fill="both", expand=True, pady=(10, 0))
+        output_panel = tk.Frame(main, background=PALETTE["surface"], padx=18, pady=16, highlightbackground=PALETTE["line"], highlightthickness=1)
+        output_panel.grid(row=0, column=1, sticky="nsew")
+        output_panel.rowconfigure(2, weight=1)
+        output_panel.columnconfigure(0, weight=1)
+
+        ttk.Label(output_panel, text="Result", style="Heading.TLabel").grid(row=0, column=0, sticky="w")
+        self.status_var = tk.StringVar(value="Ready")
+        ttk.Label(output_panel, textvariable=self.status_var, style="Hint.TLabel").grid(row=1, column=0, sticky="w", pady=(2, 12))
+        self.output = tk.Text(output_panel, wrap="word", height=18, borderwidth=1, relief="solid")
+        self.output.configure(
+            background=PALETTE["surface_alt"],
+            foreground=PALETTE["ink"],
+            insertbackground=PALETTE["ink"],
+            font=("Cascadia Mono", 10),
+            padx=12,
+            pady=10,
+            relief="flat",
+            borderwidth=0,
+        )
+        self.output.grid(row=2, column=0, sticky="nsew")
         self._sync_service_fields()
 
     def _render_deprecated_services(self):
@@ -234,6 +311,8 @@ class FileUploaderGui:
     def _sync_service_fields(self):
         service = self._current_service()
         actions = actions_for_service(service)
+        self.provider_meta_var.set(provider_summary(service))
+        self.provider_status_var.set(provider_status(service).upper())
         self.action_combo.configure(values=actions)
         if self.action_var.get() not in actions:
             self.action_var.set(actions[0] if actions else "")
@@ -295,6 +374,7 @@ class FileUploaderGui:
     def _run_action(self):
         state = self._state()
         try:
+            self.status_var.set(f"Running {state.action} with {state.service}...")
             service = self._current_service()
             validate_state(state, service)
             if state.action == "upload":
@@ -308,9 +388,12 @@ class FileUploaderGui:
             if hasattr(result, "to_dict"):
                 result = result.to_dict()
             self._set_output(format_output(result, json_output=state.json_output))
+            self.status_var.set(f"Completed {state.action} with {service.display_name}.")
         except ProviderError as exc:
             self._set_output(format_output({"ok": False, "error": exc.to_dict()}, json_output=state.json_output))
+            self.status_var.set(f"{exc.provider}: {exc.message}")
         except Exception as exc:
+            self.status_var.set("Unexpected error.")
             messagebox.showerror("FileUploader", str(exc))
 
     def _copy_result(self):
@@ -318,6 +401,7 @@ class FileUploaderGui:
         self.root.clipboard_clear()
         self.root.clipboard_append(text)
         self.root.update()
+        self.status_var.set("Result copied.")
 
 
 def main():

--- a/fileuploader_tui.py
+++ b/fileuploader_tui.py
@@ -25,21 +25,23 @@ class TuiRequest:
 
 def service_table(core=None) -> Table:
     core = core or FileUploaderCore()
-    table = Table(title="FileUploader Services")
-    table.add_column("Name")
+    table = Table(title="FileUploader Services", show_header=True, header_style="bold cyan", border_style="bright_black")
+    table.add_column("Name", style="bold")
     table.add_column("Display")
-    table.add_column("Upload")
-    table.add_column("Download")
-    table.add_column("Info")
+    table.add_column("Upload", justify="center")
+    table.add_column("Download", justify="center")
+    table.add_column("Info", justify="center")
     table.add_column("Status")
     for service in core.services(include_deprecated=True):
+        status = "disabled" if not service.active else "deprecated" if service.deprecated else "active"
+        status_style = "bright_black" if status == "disabled" else "yellow" if status == "deprecated" else "green"
         table.add_row(
             service.name,
             service.display_name,
-            "yes" if service.supports_upload else "no",
-            "yes" if service.supports_download else "no",
-            "yes" if service.supports_info else "no",
-            "disabled" if not service.active else "deprecated" if service.deprecated else "active",
+            "[green]yes[/]" if service.supports_upload else "[bright_black]no[/]",
+            "[green]yes[/]" if service.supports_download else "[bright_black]no[/]",
+            "[green]yes[/]" if service.supports_info else "[bright_black]no[/]",
+            f"[{status_style}]{status}[/]",
         )
     return table
 
@@ -84,8 +86,8 @@ class FileUploaderTui:
             return {"ok": False, "error": exc.to_dict()}
 
     def interactive(self):
-        self.console.print(Panel.fit(banner_text(), title="FileUploader TUI"))
-        self.console.print("Pick a provider, choose an action, then fill only the fields requested.")
+        self.console.print(Panel.fit(banner_text(), title="[bold cyan]FileUploader TUI[/]", border_style="cyan"))
+        self.console.print("[bright_black]Pick a provider, choose an action, then fill only the fields requested.[/]")
         self.console.print(service_table(self.core))
         services = [service.name for service in self.core.services(include_deprecated=True)]
         while True:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -9,6 +9,8 @@ from fileuploader_gui import (
     default_service_name,
     default_state,
     deprecated_services,
+    provider_status,
+    provider_summary,
     required_fields_for_state,
     service_names,
     validate_state,
@@ -42,14 +44,28 @@ class GuiSmokeTests(unittest.TestCase):
 
         self.assertEqual(error.exception.code, "path_required")
 
-    def test_active_services_excludes_deprecated_services(self):
+    def test_active_services_excludes_deprecated_and_disabled_services(self):
         services = [
             ProviderInfo(name="gofile", display_name="GoFile"),
             ProviderInfo(name="bayfiles", display_name="BayFiles", deprecated=True),
+            ProviderInfo(name="mega", display_name="MEGA", active=False),
         ]
 
         self.assertEqual(service_names(active_services(services)), ["gofile"])
-        self.assertEqual(service_names(deprecated_services(services)), ["bayfiles"])
+        self.assertEqual(service_names(deprecated_services(services)), ["bayfiles", "mega"])
+
+    def test_provider_status_labels_state(self):
+        self.assertEqual(provider_status(ProviderInfo(name="gofile", display_name="GoFile")), "active")
+        self.assertEqual(provider_status(ProviderInfo(name="bayfiles", display_name="BayFiles", deprecated=True)), "deprecated")
+        self.assertEqual(provider_status(ProviderInfo(name="mega", display_name="MEGA", active=False)), "disabled")
+
+    def test_provider_summary_mentions_capabilities_and_credentials(self):
+        summary = provider_summary(ProviderInfo(name="box", display_name="Box", supports_info=True, requires_api_key=True))
+
+        self.assertIn("Box", summary)
+        self.assertIn("upload", summary)
+        self.assertIn("info", summary)
+        self.assertIn("token required", summary)
 
     def test_default_service_prefers_gofile(self):
         services = [


### PR DESCRIPTION
## Summary
- Redesigns the Tkinter GUI with a more polished header, two-panel layout, provider status chip, clearer metadata, and cleaner result panel.
- Adds GUI palette tokens plus provider status/summary helpers for testable UI state.
- Adds live status feedback for run, error, and copy actions.
- Improves Rich TUI table styling with status colors and cleaner columns.

## Validation
- `python -m unittest discover -s tests`
- `python -m py_compile` on package modules and launchers
- Tkinter smoke construction
- `python -c "from fileuploader_tui import service_table; print(len(service_table().rows))"`

Closes #34.