### PR TITLE
Polish README and project presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
 # FileUploader
 
-Unified Python tooling for uploading files to multiple file-hosting providers.
+Unified Python tooling for uploading files through CLI, GUI, and TUI workflows.
 
-[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-active-success.svg)](#supported-providers)
+[![Python](https://img.shields.io/badge/python-3.10%2B-2563eb.svg)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-047857.svg)](LICENSE)
+[![Providers](https://img.shields.io/badge/providers-23-0f766e.svg)](#provider-matrix)
+[![Interfaces](https://img.shields.io/badge/interfaces-CLI%20%7C%20GUI%20%7C%20TUI-111827.svg)](#interfaces)
+[![Validation](https://img.shields.io/badge/tests-unittest-7c3aed.svg)](#development)
 
-FileUploader provides a shared provider layer plus three user interfaces:
-
-- **CLI** for automation and scripts: `python -m fileuploader_cli`
-- **GUI** for desktop users: `python -m fileuploader_gui`
-- **TUI** for guided terminal use: `python -m fileuploader_tui`
-
-`python -m fileuploader` is kept as an equivalent package entrypoint for the same CLI.
+FileUploader gives you one normalized upload core for temporary file hosts, cloud-backed providers, and legacy upload scripts. Use it from a modern CLI, a lightweight desktop GUI, or a Rich-powered terminal UI.
 
 Created by **j0rd1s3rr4n0**: [jordiserrano.me](https://jordiserrano.me) | [github.com/j0rd1s3rr4n0](https://github.com/j0rd1s3rr4n0)
 
-The current provider set includes GoFile, a broad no-registration upload set, and account-backed cloud providers such as Box, Dropbox, MediaFire, and MEGA. Deprecated providers remain available for compatibility, but upstream APIs may be unreliable.
+## Why FileUploader
 
-## Features
+Most file hosts expose different request shapes, response formats, and failure messages. FileUploader wraps them behind one interface with normalized provider metadata, upload results, and errors.
 
-| Feature | Description |
+| What you need | Use this |
 | --- | --- |
-| Unified provider core | Normalized provider metadata, upload results, and errors across services. |
-| Multiple interfaces | CLI, Tkinter GUI, and Rich TUI use the same core behavior. |
-| API key support | Pass keys directly or through environment variables. |
-| Encryption support | GoFile legacy workflow supports local AES-GCM encrypt/decrypt before and after transfer. |
-| Clipboard support | Copy processed output from supported workflows. |
-| Testable design | Provider and UI tests use mocks and avoid network access. |
+| Quick public link, no account | `catbox`, `fileio`, `0x0`, `tempsh`, `transfersh`, `gofile` |
+| Automation and scripting | `python -m fileuploader_cli ... --json --no-banner` |
+| Desktop workflow | `python -m fileuploader_gui` |
+| Interactive terminal flow | `python -m fileuploader_tui` |
+| Account-backed storage | `box`, `dropbox`, `mediafire`, `jsonbin`, `anonfilesnew` |
 
-## Installation
+## Interfaces
+
+| Interface | Command | Best for |
+| --- | --- | --- |
+| CLI | `python -m fileuploader_cli` | Scripts, CI jobs, JSON output, repeatable commands |
+| Package CLI | `python -m fileuploader` | Equivalent package entrypoint for the same CLI |
+| GUI | `python -m fileuploader_gui` | Provider-aware desktop uploads and copyable results |
+| TUI | `python -m fileuploader_tui` | Guided terminal use with Rich tables and prompts |
+
+## Quick Start
+
+Install dependencies:
 
 ```shell
 git clone https://github.com/j0rd1s3rr4n0/FileUploader.git
@@ -37,53 +43,28 @@ cd FileUploader
 python -m pip install -r requirements.txt
 ```
 
-## Quick Start
-
-List all providers:
+List providers:
 
 ```shell
 python -m fileuploader_cli services
 ```
 
-Hide the terminal banner and credits when scripting:
+Upload without registration:
 
 ```shell
-python -m fileuploader_cli --no-banner services
+python -m fileuploader_cli upload --service catbox path/to/file.txt
 ```
 
-Use the guided CLI when you do not remember the flags:
-
-```shell
-python -m fileuploader_cli guided
-```
-
-Upload a file with GoFile and print JSON:
+Upload with JSON output for scripts:
 
 ```shell
 python -m fileuploader_cli upload --service gofile path/to/file.txt --json
 ```
 
-Upload without registration:
+Hide the banner for automation:
 
 ```shell
-python -m fileuploader_cli upload --service moonpush path/to/file.txt
-python -m fileuploader_cli upload --service 0x0 path/to/file.txt
-python -m fileuploader_cli upload --service tmpfilelink path/to/file.txt
-python -m fileuploader_cli upload --service catbox path/to/file.txt
-python -m fileuploader_cli upload --service fileio path/to/file.txt
-```
-
-Upload with AnonFilesNew using an API key:
-
-```shell
-python -m fileuploader_cli upload --service anonfilesnew path/to/file.txt --api-key YOUR_API_KEY --json
-```
-
-Use an API key from an environment variable:
-
-```shell
-set ANONFILESNEW_API_KEY=YOUR_API_KEY
-python -m fileuploader_cli upload --service anonfilesnew path/to/file.txt --api-key-env ANONFILESNEW_API_KEY
+python -m fileuploader_cli --no-banner services
 ```
 
 Launch the desktop GUI:
@@ -98,6 +79,58 @@ Launch the terminal UI:
 python -m fileuploader_tui
 ```
 
+## Common Workflows
+
+### No Account Required
+
+Use these first when you just need a public link and do not want to create an account or pass tokens:
+
+```shell
+python -m fileuploader_cli upload --service catbox path/to/file.txt
+python -m fileuploader_cli upload --service fileio path/to/file.txt
+python -m fileuploader_cli upload --service 0x0 path/to/file.txt
+python -m fileuploader_cli upload --service transfersh path/to/file.txt
+python -m fileuploader_cli upload --service tempsh path/to/file.txt
+```
+
+### Copy-Friendly Output
+
+Human output is readable by default. JSON output is clean and banner-free:
+
+```shell
+python -m fileuploader_cli upload --service gofile path/to/file.txt --json
+```
+
+Some workflows also support copying processed output:
+
+```shell
+python -m fileuploader_cli upload --service catbox path/to/file.txt --copy
+```
+
+### API Keys and Tokens
+
+Pass credentials directly:
+
+```shell
+python -m fileuploader_cli upload --service anonfilesnew path/to/file.txt --api-key YOUR_API_KEY
+python -m fileuploader_cli upload --service box path/to/file.txt --api-key BOX_OAUTH_ACCESS_TOKEN
+```
+
+Or read them from environment variables:
+
+```shell
+set ANONFILESNEW_API_KEY=YOUR_API_KEY
+python -m fileuploader_cli upload --service anonfilesnew path/to/file.txt --api-key-env ANONFILESNEW_API_KEY
+```
+
+### Guided CLI
+
+When you do not remember the flags, use the guided flow:
+
+```shell
+python -m fileuploader_cli guided
+```
+
 ## CLI Reference
 
 ```shell
@@ -108,118 +141,161 @@ python -m fileuploader_cli [--no-banner] download --service SERVICE [--url URL] 
 python -m fileuploader_cli [--no-banner] info FILE_ID --service SERVICE [--api-key KEY] [--api-key-env ENV] [--json]
 ```
 
-See [docs/interfaces.md](docs/interfaces.md) for the interface design notes and framework comparison.
+## Preview
 
-## Supported Providers
+CLI service list:
 
-| Provider | Service name | Upload | Download | Info | API key | Status |
+```text
+Service       Upload  Download  Info  API key  Status
+------------  ------  --------  ----  -------  ------
+catbox        yes     no        no    no       active
+fileio        yes     no        no    no       active
+gofile        yes     yes       no    no       active
+jsonbin       yes     no        no    yes      active
+mega          no      no        no    yes      disabled
+```
+
+GUI workflow:
+
+```text
+Choose provider -> choose action -> enter only required fields -> run -> copy result
+```
+
+TUI workflow:
+
+```text
+Rich provider table -> guided prompts -> normalized result panel
+```
+
+## Features
+
+| Feature | Description |
+| --- | --- |
+| Unified provider core | One interface for provider metadata, upload results, and provider errors. |
+| Provider-aware UX | CLI, GUI, and TUI ask only for the fields needed by the selected action. |
+| No-registration providers | Many services work without account creation or API keys. |
+| Account-backed providers | Box, Dropbox, MediaFire, JSONBin, and AnonFilesNew support token/key workflows. |
+| JSON automation | `--json` returns parseable output without banner text. |
+| Script-friendly banner control | `--no-banner` hides the terminal banner for automation. |
+| Clipboard support | Copy supported outputs directly from CLI/GUI flows. |
+| GoFile encryption workflow | Legacy GoFile scripts support AES-GCM encrypt/decrypt helpers. |
+| Testable design | Tests use mocked providers and avoid real network calls. |
+
+## Provider Matrix
+
+| Provider | Service | Upload | Download | Info | API key | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| GoFile | `gofile` | Yes | Yes | No | No | Active |
 | 0x0.st | `0x0` | Yes | No | No | No | Active |
+| AnonFilesNew | `anonfilesnew` | Yes | No | Yes | Yes | Active |
+| blipbin | `blipbin` | Yes | No | No | No | Active |
+| Box | `box` | Yes | No | Yes | Yes | Active |
+| Catbox | `catbox` | Yes | No | No | No | Active |
+| cupload.io | `cupload` | Yes | No | No | No | Active |
+| Dropbox | `dropbox` | Yes | No | Yes | Yes | Active |
+| dropfile.dev | `dropfiledev` | Yes | No | No | No | Active |
+| EasySend | `easysend` | Yes | No | No | No | Active |
+| file.io | `fileio` | Yes | No | No | No | Active |
+| GoFile | `gofile` | Yes | Yes | No | No | Active |
+| JSONBin | `jsonbin` | Yes | No | No | Yes | Active |
+| Litterbox | `litterbox` | Yes | No | No | No | Active |
+| MediaFire | `mediafire` | Yes | No | No | Yes | Active |
 | MoonPush | `moonpush` | Yes | No | Yes | No | Active |
+| qurl.sh | `qurl` | Yes | No | No | No | Active |
 | Temp.sh | `tempsh` | Yes | No | No | No | Active |
 | tmpfile.link | `tmpfilelink` | Yes | No | No | No | Active |
-| blipbin | `blipbin` | Yes | No | No | No | Active |
-| EasySend | `easysend` | Yes | No | No | No | Active |
-| dropfile.dev | `dropfiledev` | Yes | No | No | No | Active |
-| cupload.io | `cupload` | Yes | No | No | No | Active |
-| qurl.sh | `qurl` | Yes | No | No | No | Active |
-| file.io | `fileio` | Yes | No | No | No | Active |
-| Uguu | `uguu` | Yes | No | No | No | Active |
-| Catbox | `catbox` | Yes | No | No | No | Active |
-| Litterbox | `litterbox` | Yes | No | No | No | Active |
 | transfer.sh | `transfersh` | Yes | No | No | No | Active |
-| Box | `box` | Yes | No | Yes | Yes | Active |
-| Dropbox | `dropbox` | Yes | No | Yes | Yes | Active |
-| MediaFire | `mediafire` | Yes | No | No | Yes | Active |
+| Uguu | `uguu` | Yes | No | No | No | Active |
 | MEGA | `mega` | No | No | No | Yes | Disabled |
-| AnonFilesNew | `anonfilesnew` | Yes | No | Yes | Yes | Active |
-| JSONBin | `jsonbin` | Yes | No | No | Yes | Active |
 | AnonFiles | `anonfiles` | Yes | No | No | No | Deprecated |
 | BayFiles | `bayfiles` | Yes | No | No | No | Deprecated |
 
-## Provider-Specific Notes
+## Provider Notes
 
-### No-registration providers
+### Recommended No-Registration Providers
 
-Use these when you want a quick public link without creating an account or passing API keys:
+| Service | Good for |
+| --- | --- |
+| `catbox` | Simple public file links |
+| `fileio` | Temporary links with JSON responses |
+| `0x0` | Minimal terminal uploads |
+| `tempsh` | Temporary file sharing |
+| `transfersh` | Terminal-first uploads via PUT |
+| `gofile` | Upload plus basic download support |
 
-```shell
-python -m fileuploader_cli upload --service moonpush path/to/file.txt
-python -m fileuploader_cli upload --service tempsh path/to/file.txt
-python -m fileuploader_cli upload --service blipbin path/to/file.txt
-python -m fileuploader_cli upload --service dropfiledev path/to/file.txt
-python -m fileuploader_cli upload --service catbox path/to/file.txt
-python -m fileuploader_cli upload --service transfersh path/to/file.txt
-```
+Retention, file size limits, rate limits, and content policies are controlled by each upstream provider.
 
-The no-registration providers are best for temporary sharing and automation. Retention, size limits, and rate limits are controlled by each upstream service.
+### Account-Backed Providers
 
-### Account-backed cloud providers
+| Service | Credential |
+| --- | --- |
+| `anonfilesnew` | API key |
+| `box` | OAuth access token |
+| `dropbox` | OAuth access token |
+| `jsonbin` | JSONBin API key |
+| `mediafire` | MediaFire session token |
 
-Box, Dropbox, and MediaFire require account credentials or access tokens:
+Prefer `--api-key-env` for repeat usage so secrets stay outside shell history.
 
-```shell
-python -m fileuploader_cli upload --service box path/to/file.txt --api-key BOX_OAUTH_ACCESS_TOKEN
-python -m fileuploader_cli upload --service dropbox path/to/file.txt --api-key DROPBOX_OAUTH_ACCESS_TOKEN
-python -m fileuploader_cli upload --service mediafire path/to/file.txt --api-key MEDIAFIRE_SESSION_TOKEN
-```
+### Disabled and Deprecated Providers
 
-Environment variable shortcuts are also supported:
+Disabled providers are shown in service lists but are not offered as active GUI choices. Deprecated providers remain available for compatibility, but upstream APIs may fail or disappear.
 
-```shell
-set BOX_ACCESS_TOKEN=...
-set DROPBOX_ACCESS_TOKEN=...
-set MEDIAFIRE_SESSION_TOKEN=...
-python -m fileuploader_cli upload --service dropbox path/to/file.txt --api-key-env DROPBOX_ACCESS_TOKEN
-```
+MEGA is currently disabled because reliable uploads need MEGAcmd or an SDK-backed implementation rather than a simple HTTP upload endpoint.
 
-MEGA is listed as disabled because reliable uploads require MEGAcmd or an SDK-backed implementation rather than a simple HTTP upload endpoint.
+## Security and Privacy
 
-### GoFile
+- Treat public upload links as public unless the provider explicitly says otherwise.
+- Do not upload secrets, private keys, credentials, or sensitive personal data to public hosts.
+- Prefer environment variables for tokens and API keys.
+- FileUploader normalizes provider responses, but storage, deletion, retention, and abuse policies belong to each upstream service.
+- Local tests use mocked HTTP clients and do not upload files.
 
-GoFile supports upload and download through the unified CLI. The legacy GoFile entrypoint also supports local encryption, local decryption, output formatting, and clipboard copying:
+## Legacy Workflows
+
+The unified interfaces should be the default for new usage. Legacy provider scripts remain available for specialized flows.
+
+GoFile encryption helpers:
 
 ```shell
 python GoFile/main.py -u path/to/file.txt --encrypt --password "your-password"
 python GoFile/main.py --decrypt-file file.txt.enc --password "your-password" --decrypt-output file.txt
 ```
 
-### AnonFilesNew
-
-AnonFilesNew requires an API key for account uploads. Use `--api-key` or `--api-key-env ANONFILESNEW_API_KEY`.
-
-Legacy entrypoint:
+AnonFilesNew legacy entrypoint:
 
 ```shell
 python AnonFilesNew.com/anonfilesnew.py path/to/file.txt --api-key YOUR_API_KEY --json
 ```
 
-### JSONBin
-
-JSONBin stores file content as JSON records and requires an API key. The provider also has a chunk uploader for larger workflows:
+JSONBin chunk uploader:
 
 ```shell
 python JSONBin.com/jsonbin_uploader.py upload path/to/file.txt --api-key YOUR_API_KEY --manifest upload-manifest.json
 ```
 
-Use multiple JSONBin keys by repeating `--api-key` or setting `JSONBIN_API_KEYS` with comma-separated values.
-
 ## Development
 
-Run the full test suite:
+Install locally:
+
+```shell
+git clone https://github.com/j0rd1s3rr4n0/FileUploader.git
+cd FileUploader
+python -m pip install -r requirements.txt
+```
+
+Run tests:
 
 ```shell
 python -m unittest discover -s tests
 ```
 
-Compile the main modules:
+Compile modules:
 
 ```shell
-python -m py_compile fileuploader/*.py fileuploader_cli.py fileuploader_gui.py fileuploader_tui.py
+python -m compileall fileuploader fileuploader_cli.py fileuploader_gui.py fileuploader_tui.py
 ```
 
-Expected local smoke checks:
+Smoke checks:
 
 ```shell
 python -m fileuploader_cli services --json
@@ -228,7 +304,7 @@ python -c "from fileuploader_tui import service_table; print(len(service_table()
 python -c "import fileuploader_gui; print(fileuploader_gui.default_state())"
 ```
 
-## Project Layout
+Project layout:
 
 ```text
 fileuploader/       Shared provider core, registry, formatters, and CLI
@@ -242,9 +318,28 @@ tests/              Unit and smoke tests
 docs/               Interface documentation
 ```
 
+## Roadmap
+
+Planned improvements:
+
+- Provider health checks and capability reporting.
+- Batch uploads across CLI, GUI, and TUI.
+- Local upload history with export.
+- Config profiles for defaults and environment variable names.
+- Retry, timeout, and backoff policy.
+- Output formats for URL-only, Markdown, HTML, text, and JSON.
+- Packaging with installable console commands.
+
 ## Contributing
 
-Pull requests are welcome. For larger changes, open an issue first with the intended behavior, provider impact, and validation plan.
+Pull requests are welcome. For larger changes, open an issue with:
+
+- the user-facing behavior;
+- affected providers or interfaces;
+- expected tests;
+- compatibility risks.
+
+Keep new providers behind the shared provider core and cover them with mocked tests.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrites README into a more polished GitHub project page with clearer hero, badges, workflow examples, previews, provider matrix, security notes, development steps, roadmap, and contribution guidance.
- Highlights no-registration providers as the fastest starting path.
- Separates account-backed, disabled, deprecated, and legacy workflows.
- Keeps all registered providers represented in the matrix.

## Validation
- `python -m unittest discover -s tests`
- `python -m compileall fileuploader fileuploader_cli.py fileuploader_gui.py fileuploader_tui.py`
- `python -m fileuploader_cli --no-banner services`
- `python -m fileuploader_cli services --json`
- `rg -n -i "conflict markers / prohibited terms" README.md docs` returned no matches
- Checked registered providers are all present in README

Closes #38.