### PR TITLE
Add 4shared provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unified Python tooling for uploading files through CLI, GUI, and TUI workflows.
 
 [![Python](https://img.shields.io/badge/python-3.10%2B-2563eb.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-MIT-047857.svg)](LICENSE)
-[![Providers](https://img.shields.io/badge/providers-23-0f766e.svg)](#provider-matrix)
+[![Providers](https://img.shields.io/badge/providers-24-0f766e.svg)](#provider-matrix)
 [![Interfaces](https://img.shields.io/badge/interfaces-CLI%20%7C%20GUI%20%7C%20TUI-111827.svg)](#interfaces)
 [![Validation](https://img.shields.io/badge/tests-unittest-7c3aed.svg)](#development)
 
@@ -22,7 +22,7 @@ Most file hosts expose different request shapes, response formats, and failure m
 | Automation and scripting | `python -m fileuploader_cli ... --json --no-banner` |
 | Desktop workflow | `python -m fileuploader_gui` |
 | Interactive terminal flow | `python -m fileuploader_tui` |
-| Account-backed storage | `box`, `dropbox`, `mediafire`, `jsonbin`, `anonfilesnew` |
+| Account-backed storage | `4shared`, `box`, `dropbox`, `mediafire`, `jsonbin`, `anonfilesnew` |
 
 ## Interfaces
 
@@ -114,6 +114,7 @@ Pass credentials directly:
 ```shell
 python -m fileuploader_cli upload --service anonfilesnew path/to/file.txt --api-key YOUR_API_KEY
 python -m fileuploader_cli upload --service box path/to/file.txt --api-key BOX_OAUTH_ACCESS_TOKEN
+python -m fileuploader_cli upload --service 4shared path/to/file.txt --api-key "oauth_token=...&oauth_signature=..."
 ```
 
 Or read them from environment variables:
@@ -186,6 +187,7 @@ Rich provider table -> guided prompts -> normalized result panel
 | Provider | Service | Upload | Download | Info | API key | Status |
 | --- | --- | --- | --- | --- | --- | --- |
 | 0x0.st | `0x0` | Yes | No | No | No | Active |
+| 4shared | `4shared` | Yes | No | Yes | Yes | Active |
 | AnonFilesNew | `anonfilesnew` | Yes | No | Yes | Yes | Active |
 | blipbin | `blipbin` | Yes | No | No | No | Active |
 | Box | `box` | Yes | No | Yes | Yes | Active |
@@ -228,6 +230,7 @@ Retention, file size limits, rate limits, and content policies are controlled by
 
 | Service | Credential |
 | --- | --- |
+| `4shared` | OAuth query parameters |
 | `anonfilesnew` | API key |
 | `box` | OAuth access token |
 | `dropbox` | OAuth access token |
@@ -235,6 +238,8 @@ Retention, file size limits, rate limits, and content policies are controlled by
 | `mediafire` | MediaFire session token |
 
 Prefer `--api-key-env` for repeat usage so secrets stay outside shell history.
+
+For `4shared`, pass the already signed OAuth query string through `--api-key` or `FOURSHARED_OAUTH_PARAMS`. The provider uses the simple upload endpoint for files below 150 MB and uploads to folder `0` unless a future interface supplies a different `folder_id`.
 
 ### Disabled and Deprecated Providers
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -36,7 +36,7 @@ Use `--no-banner` before the command when you want machine-friendly human output
 
 For quick temporary sharing, prefer the no-registration providers such as `moonpush`, `0x0`, `tempsh`, `tmpfilelink`, `blipbin`, `easysend`, `dropfiledev`, `cupload`, `qurl`, `fileio`, `uguu`, `catbox`, `litterbox`, and `transfersh`.
 
-For account-backed storage, use `box`, `dropbox`, or `mediafire` with `--api-key` or `--api-key-env`. `mega` is shown as disabled until a MEGAcmd or SDK-backed implementation is added.
+For account-backed storage, use `4shared`, `box`, `dropbox`, or `mediafire` with `--api-key` or `--api-key-env`. `4shared` expects signed OAuth query parameters; `mega` is shown as disabled until a MEGAcmd or SDK-backed implementation is added.
 
 Typer is used because it provides a modern command surface while building on Click internally. Click is therefore covered as the underlying command framework. The older argparse scripts remain available as legacy provider-specific entrypoints, but new automation should use `python -m fileuploader`.
 

--- a/fileuploader/providers.py
+++ b/fileuploader/providers.py
@@ -482,6 +482,54 @@ class TransferShProvider(BaseProvider):
         return UploadResult(provider=self.info.name, status=True, url=url, raw={"response": url})
 
 
+class FourSharedProvider(BaseProvider):
+    info = ProviderInfo(
+        name="4shared",
+        display_name="4shared",
+        supports_download=False,
+        supports_info=True,
+        requires_api_key=True,
+    )
+
+    def _oauth_params(self, options):
+        oauth_params = self._api_key(options, "FOURSHARED_OAUTH_PARAMS", "4shared OAuth query parameters")
+        return oauth_params.lstrip("?")
+
+    def upload(self, filepath, **options):
+        path = self._ensure_file(filepath)
+        oauth_params = self._oauth_params(options)
+        folder_id = options.get("folder_id") or "0"
+        params = {"folderId": folder_id, "fileName": path.name}
+        url = f"https://upload.4shared.com/v1_2/files?{oauth_params}"
+        try:
+            with path.open("rb") as file_handle:
+                response = self.http.post(
+                    url,
+                    params=params,
+                    headers={"Content-Type": "application/octet-stream"},
+                    data=file_handle,
+                )
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        payload = self._json_response(response)
+        return UploadResult(
+            provider=self.info.name,
+            status=True,
+            url=payload.get("downloadPage") or payload.get("url"),
+            file_id=payload.get("id"),
+            metadata=payload,
+            raw=payload,
+        )
+
+    def info_file(self, file_id, **options):
+        oauth_params = self._oauth_params(options)
+        try:
+            response = self.http.get(f"https://api.4shared.com/v1_2/files/{file_id}?{oauth_params}")
+        except requests.RequestException as exc:
+            raise ProviderError(self.info.name, str(exc), code="network_error") from exc
+        return self._json_response(response)
+
+
 class BoxProvider(BaseProvider):
     info = ProviderInfo(
         name="box",

--- a/fileuploader/registry.py
+++ b/fileuploader/registry.py
@@ -1,5 +1,6 @@
 from .models import ProviderError
 from .providers import (
+    FourSharedProvider,
     AnonFilesNewProvider,
     AnonFilesProvider,
     BayFilesProvider,
@@ -67,6 +68,7 @@ def create_default_registry():
             CatboxProvider(),
             LitterboxProvider(),
             TransferShProvider(),
+            FourSharedProvider(),
             BoxProvider(),
             DropboxProvider(),
             MediaFireProvider(),

--- a/tests/test_provider_core.py
+++ b/tests/test_provider_core.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fileuploader import FileUploaderCore, ProviderError, create_default_registry
 from fileuploader.providers import (
+    FourSharedProvider,
     AnonFilesNewProvider,
     BlipbinProvider,
     BoxProvider,
@@ -69,6 +70,7 @@ class ProviderCoreTests(unittest.TestCase):
         self.assertEqual(
             {
                 "0x0",
+                "4shared",
                 "anonfiles",
                 "anonfilesnew",
                 "bayfiles",
@@ -109,6 +111,7 @@ class ProviderCoreTests(unittest.TestCase):
         self.assertIn("dropbox", names)
         self.assertIn("fileio", names)
         self.assertIn("catbox", names)
+        self.assertIn("4shared", names)
 
     def test_unknown_provider_raises_normalized_error(self):
         with self.assertRaises(ProviderError) as error:
@@ -348,6 +351,38 @@ class ProviderCoreTests(unittest.TestCase):
         self.assertEqual(result.url, "https://box.com/s/file")
         self.assertEqual(result.file_id, "box-file-1")
         self.assertEqual(http.calls[0][2]["headers"]["Authorization"], "Bearer box-token")
+
+    def test_4shared_upload_uses_oauth_params_and_folder(self):
+        payload = {
+            "id": "four-file-1",
+            "name": "sample.txt",
+            "downloadPage": "https://www.4shared.com/file/four-file-1/sample.html",
+        }
+        http = FakeHttp(payload)
+        provider = FourSharedProvider(http_client=http)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "sample.txt"
+            source.write_text("data", encoding="utf-8")
+            result = provider.upload(source, api_key="?oauth_token=tok&oauth_signature=sig", folder_id="folder-1")
+
+        self.assertEqual(result.provider, "4shared")
+        self.assertEqual(result.url, "https://www.4shared.com/file/four-file-1/sample.html")
+        self.assertEqual(result.file_id, "four-file-1")
+        self.assertEqual(http.calls[0][1], "https://upload.4shared.com/v1_2/files?oauth_token=tok&oauth_signature=sig")
+        self.assertEqual(http.calls[0][2]["params"]["folderId"], "folder-1")
+        self.assertEqual(http.calls[0][2]["params"]["fileName"], "sample.txt")
+        self.assertEqual(http.calls[0][2]["headers"]["Content-Type"], "application/octet-stream")
+
+    def test_4shared_info_uses_oauth_params(self):
+        payload = {"id": "four-file-1", "name": "sample.txt"}
+        http = FakeHttp(payload)
+        provider = FourSharedProvider(http_client=http)
+
+        result = provider.info_file("four-file-1", api_key="oauth_token=tok")
+
+        self.assertEqual(result["id"], "four-file-1")
+        self.assertEqual(http.calls[0][1], "https://api.4shared.com/v1_2/files/four-file-1?oauth_token=tok")
 
     def test_dropbox_upload_uses_content_endpoint(self):
         payload = {"id": "dropbox-file-1", "path_display": "/sample.txt", "name": "sample.txt"}


### PR DESCRIPTION
## Summary
- Adds `4shared` as an account-backed provider using signed OAuth query parameters.
- Supports simple uploads through the 4shared `/v1_2/files` endpoint and info lookup through `/v1_2/files/{id}`.
- Registers the provider for CLI, GUI, and TUI discovery.
- Updates README and interface docs to document 4shared credential expectations.

## Validation
- `python -m unittest discover -s tests`
- `python -m compileall fileuploader fileuploader_cli.py fileuploader_gui.py fileuploader_tui.py`
- `python -m fileuploader_cli --no-banner services --active-only`
- `python -m fileuploader_cli services --json`
- Tkinter GUI smoke construction
- TUI service table smoke check
- README provider matrix check

Closes #40.